### PR TITLE
[WIP] Add basics for validation and introspection

### DIFF
--- a/pkg/integration/introspection_data.go
+++ b/pkg/integration/introspection_data.go
@@ -1,0 +1,94 @@
+// Copyright 2019, Red Hat
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package integration
+
+// This structure not a complete example of ironic introspection data.
+// To be completed as needed as we go...
+type IntrospectionData struct {
+	Name      string    `json:"name"`
+	Inventory Inventory `json:"inventory"`
+}
+
+type Inventory struct {
+	Disks []Disk `json:"disks"`
+}
+
+type Disk struct {
+	ByPath             string `json:"by_path"`
+	Model              string `json:"model"`
+	Name               string `json:"name"`
+	Rotational         bool   `json:"rotational"`
+	Serial             string `json:"serial"`
+	Size               int    `json:"size"`
+	Vendor             string `json:"vendor"`
+	Wwn                string `json:"wwn"`
+	WwnVendorExtension string `json:"wwn_vendor_extension"`
+	WwnWithExtension   string `json:"wwn_with_extension"`
+}
+
+func GetIntrospectionData(host string) (IntrospectionData, error) {
+    hostsIntrospectionData := []IntrospectionData{
+        IntrospectionData{
+            Name: "host-01",
+            Inventory: Inventory{
+                Disks: []Disk{
+                    Disk{
+                        ByPath:             "/dev/disk/by-path/pci-0000:00:05.0",
+                        Name:               "/dev/vda/",
+                        Model:              "",
+                        Rotational:         true,
+                        Serial:             "",
+                        Size:               53687091200,
+                        Vendor:             "0x1af4",
+                        Wwn:                "",
+                        WwnVendorExtension: "",
+                        WwnWithExtension:   "",
+                    },
+                },
+            },
+        },
+        IntrospectionData{
+            Name: "host-02",
+            Inventory: Inventory{
+                Disks: []Disk{
+                    Disk{
+                        ByPath:             "/dev/disk/by-path/pci-0000:00:05.0",
+                        Name:               "/dev/vda/",
+                        Model:              "",
+                        Rotational:         true,
+                        Serial:             "",
+                        Size:               10737418240,
+                        Vendor:             "0x1af4",
+                        Wwn:                "",
+                        WwnVendorExtension: "",
+                        WwnWithExtension:   "",
+                    },
+                },
+            },
+        },
+    }
+
+    returnData := hostsIntrospectionData[0];
+
+    for _, data := range hostsIntrospectionData {
+        if data.Name == host {
+            returnData = data
+        }
+    }
+
+    return returnData, nil
+
+
+}

--- a/pkg/server/handlers.go
+++ b/pkg/server/handlers.go
@@ -19,6 +19,7 @@ import (
 	"log"
 	"net/http"
 
+	"github.com/gorilla/mux"
 	"github.com/metalkube/facet/pkg/common"
 	"github.com/metalkube/facet/pkg/integration"
 )
@@ -68,6 +69,15 @@ func CreateClusterDefinition(w http.ResponseWriter, r *http.Request) {
 		// TODO(jtomasek): Response should be a complete InstallConfig object
 		RespondWithJson(w, pullSecret)
 	}
+}
+
+func IntrospectionDataHandler(w http.ResponseWriter, r *http.Request) {
+    vars := mux.Vars(r)
+	introspection_data, err := integration.GetIntrospectionData(vars["host"])
+	if err != nil {
+		log.Print(err)
+	}
+	RespondWithJson(w, introspection_data)
 }
 
 // This is an example of a REST API endpoint handler which will trigger a long

--- a/pkg/server/routes.go
+++ b/pkg/server/routes.go
@@ -26,6 +26,7 @@ func ApiRouter(router *mux.Router, notificationChannel chan common.Notification)
 	router.Use(jsonMiddleware)
 
 	router.HandleFunc("/hosts", HostsHandler)
+	router.HandleFunc("/introspection_data/{host:[a-z0-9-]+}", IntrospectionDataHandler)
 	router.HandleFunc("/long", LongRunningTaskHandler(notificationChannel))
 	router.HandleFunc("/bootstrap-vm", BootstrapVMHandler(notificationChannel))
 	router.HandleFunc("/cluster-definition", CreateClusterDefinition).Methods("POST")

--- a/src/actions/hosts.ts
+++ b/src/actions/hosts.ts
@@ -1,7 +1,9 @@
 import { Dispatch } from 'redux';
 import { createAsyncAction } from 'typesafe-actions';
 import { getHosts } from '../api/hosts';
+import { getIntrospectionData } from '../api/introspectionData';
 import { Host } from '../models/hosts';
+import { IntrospectionData } from '../models/introspectionData';
 
 export const fetchHosts = createAsyncAction(
   'GET_HOSTS_REQUEST',
@@ -9,11 +11,33 @@ export const fetchHosts = createAsyncAction(
   'GET_HOSTS_FAILURE'
 )<void, Host[], Error>();
 
+export const fetchIntrospectionData = createAsyncAction(
+  'GET_INTROSPECTION_DATA_REQUEST',
+  'GET_INTROSPECTION_DATA_SUCCESS',
+  'GET_INTROSPECTION_DATA_FAILURE'
+)<string, IntrospectionData, Error>();
+
 export const fetchHostsAsync = (): ((dispatch: Dispatch) => void) => (
   dispatch: Dispatch
 ) => {
   dispatch(fetchHosts.request());
   getHosts()
-    .then(response => dispatch(fetchHosts.success(response.data.data)))
+    .then(response => {
+      dispatch(fetchHosts.success(response.data.data));
+      for (let host of response.data.data) {
+        dispatch(fetchIntrospectionData.request(host.name));
+        getIntrospectionData(host.name)
+          .then(response => {
+            dispatch(fetchIntrospectionData.success(response.data.data));
+          })
+          .catch(() =>
+            dispatch(
+              fetchIntrospectionData.failure(
+                Error(`Failed to get introspection data for host ${host.name}`)
+              )
+            )
+          );
+      }
+    })
     .catch(() => dispatch(fetchHosts.failure(Error('Failed to fetch hosts'))));
 };

--- a/src/api/introspectionData.ts
+++ b/src/api/introspectionData.ts
@@ -1,0 +1,12 @@
+import axios, { AxiosPromise } from 'axios';
+import { IntrospectionData } from '../models/introspectionData';
+import { ApiResponse } from './index';
+
+type GetIntrospectionDataApiResponse = AxiosPromise<
+  ApiResponse<IntrospectionData>
+>;
+
+export const getIntrospectionData = (
+  host: string
+): GetIntrospectionDataApiResponse =>
+  axios.get(`/api/introspection_data/${host}`);

--- a/src/components/BaremetalInventory.tsx
+++ b/src/components/BaremetalInventory.tsx
@@ -8,6 +8,7 @@ import {
 
 import { fetchHostsAsync } from '../actions/hosts';
 import { getHostTableRows, getHostsLoading } from '../selectors/hosts';
+import { getHostValidationErrors } from '../selectors/validations';
 import { RootState } from '../store/rootReducer';
 import PageSection from './ui/PageSection';
 import HostsTable from './HostsTable';
@@ -18,6 +19,7 @@ import { WizardStep } from '../models/wizard';
 
 interface Props {
   hostRows: HostTableRows;
+  hostValidationErrors: any;
   loadingHosts: boolean;
   fetchHosts: () => void;
   setCurrentStep: (step: WizardStep) => void;
@@ -29,7 +31,7 @@ class BaremetalInventory extends Component<Props> {
   }
 
   render(): JSX.Element {
-    const { hostRows, loadingHosts, setCurrentStep } = this.props;
+    const { hostRows, loadingHosts, setCurrentStep, hostValidationErrors } = this.props;
     return (
       <Fragment>
         <PageSection variant={PageSectionVariants.darker}>
@@ -45,7 +47,7 @@ class BaremetalInventory extends Component<Props> {
           isMain
           style={{ padding: 0 }}
         >
-          <HostsTable hostRows={hostRows} loadingHosts={loadingHosts} />
+          <HostsTable hostRows={hostRows} loadingHosts={loadingHosts} hostValidationErrors={hostValidationErrors} />
         </PageSection>
         <ClusterWizardToolbar>
           <ToolbarButton variant="primary" isDisabled>
@@ -68,8 +70,13 @@ class BaremetalInventory extends Component<Props> {
 
 const mapStateToProps = (
   state: RootState
-): { hostRows: string[][]; loadingHosts: boolean } => ({
+): {
+  hostRows: string[][];
+  hostValidationErrors: any;
+  loadingHosts: boolean;
+} => ({
   hostRows: getHostTableRows(state),
+  hostValidationErrors: getHostValidationErrors(state),
   loadingHosts: getHostsLoading(state)
 });
 

--- a/src/components/HostsTable.tsx
+++ b/src/components/HostsTable.tsx
@@ -1,17 +1,20 @@
 import React, { FC, Fragment } from 'react';
 import { Table, TableHeader, TableBody } from '@patternfly/react-table';
-import { Bullseye } from '@patternfly/react-core';
+import { Bullseye, Button, Popover } from '@patternfly/react-core';
 import { HostTableRows } from '../models/hosts';
+import { ValidationError } from '../models/validations';
 import HostsEmptyState from './HostsEmptyState';
 
 interface Props {
   hostRows: HostTableRows;
+  hostValidationErrors: any;
   loadingHosts: boolean;
 }
 
 const HostsTable: FC<Props> = ({
   hostRows,
-  loadingHosts
+  loadingHosts,
+  hostValidationErrors
 }: Props): JSX.Element => {
   const headerStyle = {
     position: 'sticky',
@@ -30,10 +33,47 @@ const HostsTable: FC<Props> = ({
     cellFormatters: [],
     props: {}
   };
+
+  const statusFormatter = (hostStatus: any, extra: any) => {
+    let validationErrors: ValidationError[] = hostValidationErrors[extra.rowData.name.title];
+    let errorElements = validationErrors.map((error, index) => {
+        return (
+            <div key={index}>
+                <p>{error.name}</p>
+                <p>{error.message}</p>
+            </div>
+        );
+    });
+    return (
+      <div>
+      {(validationErrors.length > 0) ? (
+        <Popover
+          position="right"
+          size="regular"
+          headerContent={<div>Errors</div>}
+          bodyContent={errorElements}
+        >
+          <Button variant="plain">Errors</Button>
+        </Popover>
+      ) : (
+        <p>{hostStatus}</p>
+      )}
+    </div>
+    )
+  };
+
+  const statusColumnConfig = {
+    transfroms: [], // TODO fix the typo once it is fixed in @patternfly/react-table
+    // transforms: [],
+    cellTransforms: [],
+    formatters: [],
+    cellFormatters: [statusFormatter],
+    props: {}
+  };
   const columns = [
     { title: 'Name', ...headerConfig, ...columnConfig },
     { title: 'IP Address', ...headerConfig, ...columnConfig },
-    { title: 'Status', ...headerConfig, ...columnConfig },
+    { title: 'Status', ...headerConfig, ...statusColumnConfig },
     { title: 'CPU', ...headerConfig, ...columnConfig },
     { title: 'Memory', ...headerConfig, ...columnConfig },
     { title: 'Disk', ...headerConfig, ...columnConfig },

--- a/src/constants/validations.ts
+++ b/src/constants/validations.ts
@@ -1,0 +1,3 @@
+export const MIN_DISK_SPACE_GB = 30;
+export const MIN_RAM_GB = 8;
+export const MIN_CPUS = 2;

--- a/src/models/introspectionData.ts
+++ b/src/models/introspectionData.ts
@@ -1,0 +1,16 @@
+export interface IntrospectionDataState {
+  [name: string]: IntrospectionData;
+}
+
+export interface IntrospectionData {
+  name: string;
+  inventory: Inventory;
+}
+
+export interface Inventory {
+  disks: Disk[];
+}
+
+export interface Disk {
+  size: number;
+}

--- a/src/models/validations.ts
+++ b/src/models/validations.ts
@@ -1,0 +1,8 @@
+export interface ValidationErrors {
+  [name: string]: ValidationError[];
+}
+
+export interface ValidationError {
+  name: string;
+  message: string;
+}

--- a/src/reducers/hosts.ts
+++ b/src/reducers/hosts.ts
@@ -3,11 +3,16 @@ import { ActionType, getType } from 'typesafe-actions';
 
 import * as hosts from '../actions/hosts';
 import { Host } from '../models/hosts';
+import {
+  IntrospectionData,
+  IntrospectionDataState
+} from '../models/introspectionData';
 
 export type HostsActions = ActionType<typeof hosts>;
 
 export interface HostsState {
   hosts: Host[];
+  introspectionData: IntrospectionDataState;
   loading: boolean;
 }
 
@@ -16,6 +21,15 @@ export default combineReducers<HostsState, HostsActions>({
     switch (action.type) {
       case getType(hosts.fetchHosts.success):
         return [...action.payload];
+      default:
+        return state;
+    }
+  },
+  introspectionData: (state: IntrospectionDataState = {}, action) => {
+    switch (action.type) {
+      case getType(hosts.fetchIntrospectionData.success): {
+        return { ...state, [action.payload.name]: action.payload };
+      }
       default:
         return state;
     }

--- a/src/selectors/hosts.ts
+++ b/src/selectors/hosts.ts
@@ -9,5 +9,5 @@ export const getHostsLoading = (state: RootState): boolean =>
 
 export const getHostTableRows = createSelector(
   getHosts,
-  hosts => hosts.map(host => Object.values(host))
+  (hosts: Host[]) => hosts.map((host: Host) => Object.values(host))
 );

--- a/src/selectors/validations.ts
+++ b/src/selectors/validations.ts
@@ -1,0 +1,65 @@
+import { createSelector } from 'reselect';
+
+import {
+  MIN_DISK_SPACE_GB,
+  MIN_RAM_GB,
+  MIN_CPUS
+} from '../constants/validations';
+
+import { RootState } from '../store/rootReducer';
+import { Host } from '../models/hosts';
+import {
+  IntrospectionData,
+  IntrospectionDataState
+} from '../models/introspectionData';
+import { ValidationError, ValidationErrors } from '../models/validations';
+import { getHosts } from './hosts';
+
+export const getIntrospectionData = (
+  state: RootState
+): IntrospectionDataState => state.hosts.introspectionData;
+
+export const getHostValidationErrors = createSelector(
+  getHosts,
+  getIntrospectionData,
+  (hosts: Host[], introspectionData: IntrospectionDataState) => {
+    let validationErrors: ValidationErrors = {};
+    hosts.map(host => {
+      validationErrors[host.name] = [];
+      hostIntrospectionValidators.map(validator => {
+        let validationResult = validator(host, introspectionData[host.name]);
+        if (validationResult !== true) {
+          validationErrors[host.name].push(validationResult);
+        }
+      });
+    });
+    return validationErrors;
+  }
+);
+
+// Array of validators.
+// Make sure all host introspection validators have the same signature
+interface HostIntrospectionValidator {
+  (host: Host, introspectionData?: IntrospectionData): ValidationError | true;
+}
+let hostIntrospectionValidators: HostIntrospectionValidator[] = [];
+
+// Add disk space validation to list of validators
+hostIntrospectionValidators.push((host, introspectionData) => {
+  const GB_TO_B_FACTOR = 1073741824;
+  if (!!introspectionData) {
+    let passed: boolean = false;
+    introspectionData.inventory.disks.map(disk => {
+      if (disk.size >= MIN_DISK_SPACE_GB * GB_TO_B_FACTOR) {
+        passed = true;
+      }
+    });
+    return passed || {
+      name: 'No disk with sufficient space found.',
+      message: `${
+        host.name
+      }: No disk found that fits the minimum requirement of ${MIN_DISK_SPACE_GB}GB.`
+    };
+  }
+  return true;
+});


### PR DESCRIPTION
This patch adds:

* An API endpoint with (incomplete) dummy data for introspection.
  (Similar to the Ironic API we assume introspection data to
  be available as a separate endpoint per host.)
* TS models for introspection data (incomplete; to be amended as
  we go.)
* API functions for the frontend
* A reducer to add the introspection data to the hosts store
* An addition to the fetchHostsAsync function to fetch
  introspection data.