### PR TITLE
Use BM_INVENTORY env variable to setup proxy for development

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,11 @@ For further details about the Metal³ architecture, see [http://github.com/metal
 - `cd` into it
 - Install javascript dependencies with `yarn install`
 - Start the backend server with `go run main.go server`
-- Start the yarn server with `yarn start`
+- Start the yarn server with:
+```
+  export BM_INVENTORY=`minikube service bm-inventory --url`
+  yarn start
+```
 - Open the UI at `http://localhost:3000`
 
 [1]: https://yarnpkg.com/en/

--- a/src/setupProxy.js
+++ b/src/setupProxy.js
@@ -5,8 +5,8 @@ module.exports = function (app) {
   app.use(
     '/api',
     createProxyMiddleware({
-      // target: 'http://192.168.39.47:32074',
-      target: 'http://127.0.0.1:8081',
+      // HINT: export BM_INVENTORY=`minikube service bm-inventory --url`
+      target: process.env['BM_INVENTORY'] || 'http://unknown.bm-inventory.service.url:port',
       changeOrigin: true,
     }),
   );


### PR DESCRIPTION
To run the dev server, use simply
```
  BM_INVENTORY=`minikube service bm-inventory --url` yarn run start
```