### PR TITLE
Properly track discovery image download

### DIFF
--- a/src/api/clusters.ts
+++ b/src/api/clusters.ts
@@ -1,6 +1,6 @@
 import axios, { AxiosPromise } from 'axios';
 // import { saveAs } from 'file-saver';
-import { Cluster, ClusterCreateParams, Host } from './types';
+import { Cluster, ClusterCreateParams, Host, ImageCreateParams } from './types';
 import { API_ROOT } from '.';
 
 export const getClusters = (): AxiosPromise<Cluster[]> => axios.get(`${API_ROOT}/clusters`);
@@ -20,24 +20,14 @@ export const deleteCluster = (id: string): AxiosPromise<void> =>
 export const getClusterHosts = (id: string): AxiosPromise<Host[]> =>
   axios.get(`${API_ROOT}/clusters/${id}/hosts`);
 
-export type GetClusterDownloadsImageParams = {
-  proxyIp?: string;
-  proxyPort?: string;
-  sshPublicKey?: string;
+type ImageCreateResponse = {
+  imageId: string;
 };
-export type GetClusterDownloadsImageArgs = [string, GetClusterDownloadsImageParams];
+export const createClusterDownloadsImage = (
+  id: string,
+  params: ImageCreateParams,
+): AxiosPromise<ImageCreateResponse> =>
+  axios.post(`${API_ROOT}/clusters/${id}/downloads/image`, params);
 
-export const getClusterDownloadsImage = ([id, params]: GetClusterDownloadsImageArgs): AxiosPromise<
-  string
-> =>
-  axios.get(`${API_ROOT}/clusters/${id}/downloads/image`, {
-    params,
-    responseType: 'blob',
-    onDownloadProgress: function (progressEvent) {
-      console.log('onDownloadProgress', progressEvent);
-    },
-    headers: {
-      accept: 'application/octet-stream',
-      'Content-Disposition': 'attachment; filename="discovery.iso"; filename*="discovery.iso"',
-    },
-  });
+export const getClusterDownloadsImageUrl = (clusterId: string, imageId: string) =>
+  `/api/bm-inventory/v1/clusters/${clusterId}/downloads/image?imageId=${imageId}`;

--- a/src/api/swagger.json
+++ b/src/api/swagger.json
@@ -170,6 +170,53 @@
       }
     },
     "/clusters/{clusterId}/downloads/image": {
+      "post": {
+        "tags": ["inventory"],
+        "summary": "Create a new OpenShift per-cluster discovery ISO",
+        "operationId": "GenerateClusterISO",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "clusterId",
+            "description": "The ID of the cluster whose ISO to create",
+            "type": "string",
+            "format": "uuid",
+            "required": true
+          },
+          {
+            "in": "body",
+            "name": "image-create-params",
+            "description": "New ISO parameters",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/image-create-params"
+            }
+          }
+        ],
+        "responses": {
+          "201": {
+            "description": "Created ISO",
+            "schema": {
+              "type": "object",
+              "properties": {
+                "imageId": {
+                  "type": "string",
+                  "format": "uuid"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid input"
+          },
+          "404": {
+            "description": "Cluster not found"
+          },
+          "500": {
+            "description": "Internal server error"
+          }
+        }
+      },
       "get": {
         "tags": ["inventory"],
         "summary": "Download OpenShift per-cluster discovery ISO",
@@ -186,24 +233,11 @@
           },
           {
             "in": "query",
-            "name": "proxyIp",
-            "description": "The IP address of the HTTP proxy that agents should use to access the discovery service",
+            "name": "imageId",
+            "description": "The ID of a previously-created image",
             "type": "string",
-            "format": "hostname"
-          },
-          {
-            "in": "query",
-            "name": "proxyPort",
-            "description": "The port of the HTTP proxy",
-            "type": "integer",
-            "minimum": 0,
-            "maximum": 65535
-          },
-          {
-            "in": "query",
-            "name": "sshPublicKey",
-            "description": "SSH public key for debugging the installation",
-            "type": "string"
+            "format": "uuid",
+            "required": true
           }
         ],
         "responses": {
@@ -218,7 +252,7 @@
             "description": "Invalid parameters"
           },
           "404": {
-            "description": "Cluster not found"
+            "description": "Cluster or image not found"
           },
           "500": {
             "description": "Internal server error"
@@ -226,32 +260,49 @@
         }
       }
     },
-    "/clusters/{clusterId}/downloads/kubeconfig": {
+    "/clusters/{clusterId}/downloads/files": {
       "get": {
         "tags": ["inventory"],
-        "summary": "Download the kubeconfig file for the specified cluster",
-        "operationId": "DownloadClusterKubeconfig",
+        "summary": "Download files relating to the installed/installing cluster",
+        "operationId": "DownloadClusterFiles",
         "produces": ["application/octet-stream"],
         "parameters": [
           {
             "in": "path",
             "name": "clusterId",
-            "description": "The ID of the cluster whose kubeconfig to download",
+            "description": "The ID of the installed/installing cluster",
             "type": "string",
             "format": "uuid",
+            "required": true
+          },
+          {
+            "in": "query",
+            "name": "fileName",
+            "description": "The desired file to download",
+            "type": "string",
+            "enum": [
+              "bootstrap.ign",
+              "master.ign",
+              "metadata.json",
+              "worker.ign",
+              "kubeadmin-password",
+              "kubeconfig"
+            ],
             "required": true
           }
         ],
         "responses": {
           "200": {
-            "description": "The kubeconfig file",
+            "description": "The requested file",
             "schema": {
-              "type": "string",
-              "format": "binary"
+              "type": "file"
             }
           },
           "404": {
             "description": "Cluster not found"
+          },
+          "409": {
+            "description": "Conflict"
           },
           "500": {
             "description": "Internal server error"
@@ -663,6 +714,26 @@
         }
       }
     },
+    "image-create-params": {
+      "type": "object",
+      "properties": {
+        "proxyIp": {
+          "type": "string",
+          "format": "hostname",
+          "description": "The IP address of the HTTP proxy that agents should use to access the discovery service"
+        },
+        "proxyPort": {
+          "type": "integer",
+          "description": "The port of the HTTP proxy",
+          "minimum": 0,
+          "maximum": 65535
+        },
+        "sshPublicKey": {
+          "type": "string",
+          "description": "SSH public key for debugging the installation"
+        }
+      }
+    },
     "host-create-params": {
       "type": "object",
       "required": ["hostId"],
@@ -700,7 +771,8 @@
                 "insufficient",
                 "disabled",
                 "installing",
-                "installed"
+                "installed",
+                "error"
               ]
             },
             "statusInfo": {
@@ -1021,7 +1093,7 @@
             },
             "status": {
               "type": "string",
-              "enum": ["creating", "ready", "error"]
+              "enum": ["insufficient", "ready", "error", "installing", "installed"]
             },
             "hosts": {
               "x-go-custom-tag": "gorm:\"foreignkey:ClusterID;association_foreignkey:ID\"",

--- a/src/api/types.ts
+++ b/src/api/types.ts
@@ -66,7 +66,7 @@ export interface Cluster {
    * SSH public key for debugging OpenShift nodes
    */
   sshPublicKey?: string;
-  status: 'creating' | 'ready' | 'error';
+  status: 'insufficient' | 'ready' | 'error' | 'installing' | 'installed';
   hosts?: Host[];
   updatedAt?: string; // date-time
   createdAt?: string; // date-time
@@ -212,7 +212,8 @@ export interface Host {
     | 'insufficient'
     | 'disabled'
     | 'installing'
-    | 'installed';
+    | 'installed'
+    | 'error';
   statusInfo?: string;
   connectivity?: ConnectivityReport;
   hardwareInfo?: string;
@@ -223,6 +224,20 @@ export interface HostCreateParams {
   hostId: string; // uuid
 }
 export type HostList = Host[];
+export interface ImageCreateParams {
+  /**
+   * The IP address of the HTTP proxy that agents should use to access the discovery service
+   */
+  proxyIp?: string; // hostname
+  /**
+   * The port of the HTTP proxy
+   */
+  proxyPort?: number;
+  /**
+   * SSH public key for debugging the installation
+   */
+  sshPublicKey?: string;
+}
 export interface Introspection {
   cpu?: Cpu;
   'block-devices'?: BlockDevice[];

--- a/src/components/clusterWizard/HostStatus.tsx
+++ b/src/components/clusterWizard/HostStatus.tsx
@@ -13,7 +13,8 @@ type HostStatus =
   | 'insufficient'
   | 'disabled'
   | 'installing'
-  | 'installed';
+  | 'installed'
+  | 'error';
 
 const statusTitles = {
   discovering: 'Discovering',
@@ -23,6 +24,7 @@ const statusTitles = {
   disabled: 'Disabled',
   installing: 'Installing',
   installed: 'Installed',
+  error: 'Error',
 };
 
 const getStatusIcon = (status: HostStatus) => {


### PR DESCRIPTION
Image download is now split into 2 API requests, one for generating the ISO and another to actually download the image file.