### PR TITLE
Enrich HostsTable for selection of a role

### DIFF
--- a/src/components/clusterWizard/BaremetalInventory.tsx
+++ b/src/components/clusterWizard/BaremetalInventory.tsx
@@ -71,7 +71,7 @@ const BaremetalInventory: React.FC<BareMetalInventoryProps> = ({ cluster, setSte
           variant={ButtonVariant.secondary}
           component={(props) => (
             <Link to="/clusters" {...props}>
-              Cancel
+              Close
             </Link>
           )}
         ></ToolbarButton>

--- a/src/components/clusterWizard/ClusterWizardForm.tsx
+++ b/src/components/clusterWizard/ClusterWizardForm.tsx
@@ -206,7 +206,7 @@ const ClusterWizardForm: React.FC<ClusterWizardFormProps> = ({ cluster, setStep 
               variant={ButtonVariant.secondary}
               component={(props) => <Link to="/clusters" {...props} />}
             >
-              Cancel
+              Close
             </ToolbarButton>
             <ToolbarButton
               variant={ButtonVariant.secondary}

--- a/src/components/clusterWizard/HostsTable.css
+++ b/src/components/clusterWizard/HostsTable.css
@@ -1,3 +1,8 @@
 .host-table-alerts {
   padding-top: var(--pf-global--spacer--lg) !important;
 }
+
+.hosts-table .pf-c-dropdown__toggle-text {
+    color: var(--pf-global--Color--100) !important;
+}
+

--- a/src/components/clusterWizard/HostsTable.tsx
+++ b/src/components/clusterWizard/HostsTable.tsx
@@ -10,18 +10,19 @@ import {
   IRowData,
 } from '@patternfly/react-table';
 import { ConnectedIcon } from '@patternfly/react-icons';
+import { ExtraParamsType } from '@patternfly/react-table/dist/js/components/Table/base';
+import { AlertVariant } from '@patternfly/react-core';
 import { EmptyState, ErrorState } from '../ui/uiState';
 import { getColSpanRow } from '../ui/table/utils';
 import { ResourceUIState } from '../../types';
 import { Host } from '../../api/types';
+import { enableClusterHost, disableClusterHost } from '../../api/clusters';
+import { Alerts, Alert } from '../ui/Alerts';
+import { getHostRowHardwareInfo, getHardwareInfo } from './hardwareInfo';
 import { DiscoveryImageModalButton } from './discoveryImageModal';
 import HostStatus from './HostStatus';
 import { HostDetail } from './HostRowDetail';
-import { getHostRowHardwareInfo, getHardwareInfo } from './hardwareInfo';
-import { ExtraParamsType } from '@patternfly/react-table/dist/js/components/Table/base';
-import { enableClusterHost, disableClusterHost } from '../../api/clusters';
-import { Alerts, Alert } from '../ui/Alerts';
-import { AlertVariant } from '@patternfly/react-core';
+import { RoleDropdown } from './RoleDropdown';
 
 import './HostsTable.css';
 
@@ -58,8 +59,10 @@ const hostToHostTableRow = (openRows: OpenRows) => (host: Host, idx: number): IR
       isOpen: !!openRows[id],
       cells: [
         id,
-        role,
-        id, // TODO: should be serial number
+        {
+          title: <RoleDropdown role={role} host={host} />,
+        },
+        id, // TODO(mlibra): should be serial number
         { title: <HostStatus status={status} statusInfo={statusInfo} /> },
         cpu,
         memory,
@@ -213,6 +216,7 @@ const HostsTable: React.FC<HostsTableProps> = ({
         variant={variant ? variant : rows.length > 10 ? TableVariant.compact : undefined}
         aria-label="Hosts table"
         actionResolver={actionResolver}
+        className="hosts-table"
       >
         <TableHeader />
         <TableBody rowKey={rowKey} />

--- a/src/components/clusterWizard/RoleDropdown.tsx
+++ b/src/components/clusterWizard/RoleDropdown.tsx
@@ -1,0 +1,38 @@
+import React from 'react';
+import { Host, ClusterUpdateParams } from '../../api/types';
+import { SimpleDropdown } from '../ui/SimpleDropdown';
+import { patchCluster } from '../../api/clusters';
+import { HostRolesType, HOST_ROLES } from '../../config/constants';
+
+type RoleDropdownProps = {
+  role: Host['role'];
+  host: Host;
+};
+
+export const RoleDropdown: React.FC<RoleDropdownProps> = ({ role, host }) => {
+  const [isDisabled, setDisabled] = React.useState(false);
+
+  const setRole = async (role?: string) => {
+    const params: ClusterUpdateParams = {};
+    setDisabled(true);
+    params.hostsRoles = [
+      {
+        id: host.id,
+        role: role as HostRolesType,
+      },
+    ];
+    // TODO(mlibra): store updatedCluster (infra WIP) or initiate reload
+    // const updatedCluster =
+    await patchCluster(host.clusterId as string, params);
+    setDisabled(false);
+  };
+
+  return (
+    <SimpleDropdown
+      current={role as string}
+      values={HOST_ROLES}
+      setValue={setRole}
+      isDisabled={isDisabled}
+    />
+  );
+};

--- a/src/components/ui/SimpleDropdown.tsx
+++ b/src/components/ui/SimpleDropdown.tsx
@@ -1,0 +1,55 @@
+import React from 'react';
+import { DropdownItem, DropdownToggle, Dropdown } from '@patternfly/react-core';
+import { CaretDownIcon } from '@patternfly/react-icons';
+
+type SimpleDropdownProps = {
+  current?: string;
+  values: string[];
+  setValue: (value?: string) => void;
+  isDisabled: boolean;
+};
+
+export const SimpleDropdown: React.FC<SimpleDropdownProps> = ({
+  current,
+  values,
+  setValue,
+  isDisabled,
+}) => {
+  const [isOpen, setOpen] = React.useState(false);
+  const items = values.map((value) => (
+    <DropdownItem key={value} id={value}>
+      {value}
+    </DropdownItem>
+  ));
+
+  const onRoleSelect = React.useCallback(
+    (event?: React.SyntheticEvent<HTMLDivElement>) => {
+      setValue(event?.currentTarget.id);
+      setOpen(false);
+    },
+    [setValue, setOpen],
+  );
+
+  const roleToggle = React.useMemo(
+    () => (
+      <DropdownToggle
+        onToggle={(val) => setOpen(!isDisabled && val)}
+        iconComponent={CaretDownIcon}
+        isDisabled={isDisabled}
+      >
+        {current || 'Please select'}
+      </DropdownToggle>
+    ),
+    [setOpen, current, isDisabled],
+  );
+
+  return (
+    <Dropdown
+      onSelect={onRoleSelect}
+      dropdownItems={items}
+      toggle={roleToggle}
+      isOpen={isOpen}
+      isPlain
+    />
+  );
+};

--- a/src/config/constants.ts
+++ b/src/config/constants.ts
@@ -8,3 +8,7 @@ export const CLUSTER_MANAGER_SITE_LINK =
   'https://cloud.redhat.com/openshift/install/metal/user-provisioned';
 
 export const POLLING_INTERVAL = 10000;
+
+export const HOST_ROLES = ['worker', 'master'];
+// Without undefined. Otherwise must conform generated Host['roles'] - see api/types.ts
+export type HostRolesType = 'master' | 'worker';


### PR DESCRIPTION
The user can newly select role of the host within HostsTable.

TODO:
- either force UI refresh or update redux by updated cluster (after patch) - as a follow-up