### PR TITLE
Redux updates

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,7 +48,6 @@
     "redux-thunk": "^2.3.0",
     "reselect": "^4.0.0",
     "sw2dts": "^2.6.2",
-    "typesafe-actions": "^5.1.0",
     "typescript": "^3.8.3",
     "unique-names-generator": "^4.2.0",
     "yup": "^0.28.3"

--- a/src/components/clusterWizard/ClusterWizardForm.tsx
+++ b/src/components/clusterWizard/ClusterWizardForm.tsx
@@ -13,6 +13,8 @@ import {
   AlertVariant,
   AlertActionCloseButton,
   TextInputTypes,
+  TextVariants,
+  Spinner,
 } from '@patternfly/react-core';
 import { ExternalLinkAltIcon } from '@patternfly/react-icons';
 import { useDispatch } from 'react-redux';
@@ -223,7 +225,11 @@ const ClusterWizardForm: React.FC<ClusterWizardFormProps> = ({ cluster, setStep 
             <ToolbarButton variant={ButtonVariant.primary} isDisabled>
               Deploy cluster
             </ToolbarButton>
-            {isSubmitting && <ToolbarText>Saving...</ToolbarText>}
+            {isSubmitting && (
+              <ToolbarText component={TextVariants.small}>
+                <Spinner size="sm" /> Saving...
+              </ToolbarText>
+            )}
           </ClusterWizardToolbar>
         </>
       )}

--- a/src/components/clusters/ClusterPage.tsx
+++ b/src/components/clusters/ClusterPage.tsx
@@ -7,7 +7,7 @@ import { ErrorState, LoadingState } from '../ui/uiState';
 import ClusterWizard from '../clusterWizard/ClusterWizard';
 import { ResourceUIState } from '../../types';
 import { selectCurrentClusterState } from '../../selectors/currentCluster';
-import { fetchClusterAsync } from '../../features/clusters/currentClusterSlice';
+import { fetchClusterAsync, cleanCluster } from '../../features/clusters/currentClusterSlice';
 
 type MatchParams = {
   clusterId: string;
@@ -24,7 +24,10 @@ const ClusterPage: React.FC<RouteComponentProps<MatchParams>> = ({ match }) => {
 
   React.useEffect(() => {
     fetchCluster();
-  }, [clusterId, fetchCluster]);
+    return () => {
+      dispatch(cleanCluster());
+    };
+  }, [clusterId, fetchCluster, dispatch]);
 
   const cancel = (
     <Button

--- a/src/features/clusters/clustersSlice.ts
+++ b/src/features/clusters/clustersSlice.ts
@@ -37,19 +37,20 @@ export const clustersSlice = createSlice({
   name: 'clusters',
   reducers: {},
   extraReducers: (builder) => {
+    const { LOADED, LOADING, RELOADING, ERROR } = ResourceUIState;
     builder
-      .addCase(fetchClustersAsync.pending, (state) => ({
-        ...state,
-        uiState: ResourceUIState.LOADING,
-      }))
+      .addCase(fetchClustersAsync.pending, (state) => {
+        const uiState = state.uiState === LOADED ? RELOADING : LOADING;
+        return { ...state, uiState };
+      })
       .addCase(fetchClustersAsync.fulfilled, (state, action) => ({
         ...state,
         data: [...(action.payload as Cluster[])],
-        uiState: ResourceUIState.LOADED,
+        uiState: LOADED,
       }))
       .addCase(fetchClustersAsync.rejected, (state) => ({
         ...state,
-        uiState: ResourceUIState.ERROR,
+        uiState: ERROR,
       }))
       .addCase(deleteClusterAsync.fulfilled, (state, action) => ({
         ...state,

--- a/src/features/clusters/currentClusterSlice.ts
+++ b/src/features/clusters/currentClusterSlice.ts
@@ -5,7 +5,7 @@ import { handleApiError } from '../../api/utils';
 import { ResourceUIState } from '../../types';
 
 export const fetchClusterAsync = createAsyncThunk(
-  'cluster/fetchClusterAsync',
+  'currentCluster/fetchClusterAsync',
   async (clusterId: string) => {
     try {
       const { data } = await getCluster(clusterId);
@@ -28,9 +28,10 @@ const initialState: CurrentClusterStateSlice = {
 
 export const currentClusterSlice = createSlice({
   initialState,
-  name: 'cluster',
+  name: 'currentCluster',
   reducers: {
     updateCluster: (state, action: PayloadAction<Cluster>) => ({ ...state, data: action.payload }),
+    cleanCluster: () => initialState,
   },
   extraReducers: (builder) => {
     builder
@@ -50,5 +51,5 @@ export const currentClusterSlice = createSlice({
   },
 });
 
-export const { updateCluster } = currentClusterSlice.actions;
+export const { updateCluster, cleanCluster } = currentClusterSlice.actions;
 export default currentClusterSlice.reducer;

--- a/src/selectors/clusters.tsx
+++ b/src/selectors/clusters.tsx
@@ -13,8 +13,10 @@ const clustersUIState = (state: RootState) => state.clusters.uiState;
 
 export const selectClustersUIState = createSelector(
   [selectClusters, clustersUIState],
-  (clusters, uiState): ResourceUIState =>
-    !clusters.length && uiState === ResourceUIState.LOADED ? ResourceUIState.EMPTY : uiState,
+  (clusters, uiState): ResourceUIState => {
+    const { LOADED, EMPTY } = ResourceUIState;
+    return !clusters.length && uiState === LOADED ? EMPTY : uiState;
+  },
 );
 
 const clusterToClusterTableRow = (cluster: Cluster): IRow => {

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,5 +1,6 @@
 export enum ResourceUIState {
   LOADING = 'LOADING',
+  RELOADING = 'RELOADING',
   ERROR = 'ERROR',
   EMPTY = 'EMPTY',
   LOADED = 'LOADED',

--- a/yarn.lock
+++ b/yarn.lock
@@ -13203,11 +13203,6 @@ typedarray@^0.0.6:
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
   integrity sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=
 
-typesafe-actions@^5.1.0:
-  version "5.1.0"
-  resolved "https://registry.yarnpkg.com/typesafe-actions/-/typesafe-actions-5.1.0.tgz#9afe8b1e6a323af1fd59e6a57b11b7dd6623d2f1"
-  integrity sha512-bna6Yi1pRznoo6Bz1cE6btB/Yy8Xywytyfrzu/wc+NFW3ZF0I+2iCGImhBsoYYCOWuICtRO4yHcnDlzgo1AdNg==
-
 typescript@^3.8.3:
   version "3.8.3"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.8.3.tgz#409eb8544ea0335711205869ec458ab109ee1061"


### PR DESCRIPTION
Depends on https://github.com/openshift-metal3/facet/pull/69

- Remove unused typesafe-actions dependency
- Add cleanCurrentCluster action to cleanup current cluster state when unmounting ClusterPage component
- Add RELOADING state to make clusters page load smoother
- Convert Clusters component to use redux hooks instead of connect HOC