### PR TITLE
Add polling to ClusterPage

### DIFF
--- a/src/config/constants.ts
+++ b/src/config/constants.ts
@@ -6,3 +6,5 @@ export const OPENSHIFT_VERSION_OPTIONS = [
 
 export const CLUSTER_MANAGER_SITE_LINK =
   'https://cloud.redhat.com/openshift/install/metal/user-provisioned';
+
+export const POLLING_INTERVAL = 5000;

--- a/src/config/constants.ts
+++ b/src/config/constants.ts
@@ -7,4 +7,4 @@ export const OPENSHIFT_VERSION_OPTIONS = [
 export const CLUSTER_MANAGER_SITE_LINK =
   'https://cloud.redhat.com/openshift/install/metal/user-provisioned';
 
-export const POLLING_INTERVAL = 5000;
+export const POLLING_INTERVAL = 10000;

--- a/src/features/clusters/currentClusterSlice.ts
+++ b/src/features/clusters/currentClusterSlice.ts
@@ -19,13 +19,13 @@ export const fetchClusterAsync = createAsyncThunk(
 type CurrentClusterStateSlice = {
   data?: Cluster;
   uiState: ResourceUIState;
-  forceReload: number;
+  isReloadScheduled: number;
 };
 
 const initialState: CurrentClusterStateSlice = {
   data: undefined,
   uiState: ResourceUIState.LOADING,
-  forceReload: 0,
+  isReloadScheduled: 0,
 };
 
 export const currentClusterSlice = createSlice({
@@ -34,9 +34,13 @@ export const currentClusterSlice = createSlice({
   reducers: {
     updateCluster: (state, action: PayloadAction<Cluster>) => ({ ...state, data: action.payload }),
     cleanCluster: () => initialState,
-    forceReload: (state, action: PayloadAction<boolean>) => ({
+    forceReload: (state) => ({
       ...state,
-      forceReload: action.payload ? state.forceReload + 1 : 0,
+      isReloadScheduled: state.isReloadScheduled + 1,
+    }),
+    cancelForceReload: (state) => ({
+      ...state,
+      isReloadScheduled: 0,
     }),
   },
   extraReducers: (builder) => {
@@ -60,5 +64,10 @@ export const currentClusterSlice = createSlice({
   },
 });
 
-export const { updateCluster, cleanCluster, forceReload } = currentClusterSlice.actions;
+export const {
+  updateCluster,
+  cleanCluster,
+  forceReload,
+  cancelForceReload,
+} = currentClusterSlice.actions;
 export default currentClusterSlice.reducer;

--- a/src/features/clusters/currentClusterSlice.ts
+++ b/src/features/clusters/currentClusterSlice.ts
@@ -19,11 +19,13 @@ export const fetchClusterAsync = createAsyncThunk(
 type CurrentClusterStateSlice = {
   data?: Cluster;
   uiState: ResourceUIState;
+  forceReload: number;
 };
 
 const initialState: CurrentClusterStateSlice = {
   data: undefined,
   uiState: ResourceUIState.LOADING,
+  forceReload: 0,
 };
 
 export const currentClusterSlice = createSlice({
@@ -32,12 +34,19 @@ export const currentClusterSlice = createSlice({
   reducers: {
     updateCluster: (state, action: PayloadAction<Cluster>) => ({ ...state, data: action.payload }),
     cleanCluster: () => initialState,
+    forceReload: (state, action: PayloadAction<boolean>) => ({
+      ...state,
+      forceReload: action.payload ? state.forceReload + 1 : 0,
+    }),
   },
   extraReducers: (builder) => {
     builder
       .addCase(fetchClusterAsync.pending, (state) => ({
         ...state,
-        uiState: ResourceUIState.LOADING,
+        uiState:
+          state.uiState === ResourceUIState.LOADED
+            ? ResourceUIState.RELOADING
+            : ResourceUIState.LOADING,
       }))
       .addCase(fetchClusterAsync.fulfilled, (state, action) => ({
         ...state,
@@ -51,5 +60,5 @@ export const currentClusterSlice = createSlice({
   },
 });
 
-export const { updateCluster, cleanCluster } = currentClusterSlice.actions;
+export const { updateCluster, cleanCluster, forceReload } = currentClusterSlice.actions;
 export default currentClusterSlice.reducer;


### PR DESCRIPTION
The single-cluster page polls for data update.

Call
```
  dispatch(forceReloadAction(true))
```
to force refresh immediately.