### PR TITLE
Remove extra polling of hosts

### DIFF
--- a/src/components/clusterWizard/BaremetalInventory.tsx
+++ b/src/components/clusterWizard/BaremetalInventory.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { useSelector } from 'react-redux';
 import {
   ButtonVariant,
   Breadcrumb,
@@ -8,7 +9,6 @@ import {
   Text,
   TextContent,
 } from '@patternfly/react-core';
-
 import PageSection from '../ui/PageSection';
 import HostsTable from './HostsTable';
 import ClusterWizardToolbar from './ClusterWizardToolbar';
@@ -16,10 +16,9 @@ import { ToolbarButton, ToolbarText } from '../ui/Toolbar';
 import { Cluster } from '../../api/types';
 import { Link } from 'react-router-dom';
 import { WizardStep } from '../../types/wizard';
-import { getClusterHosts } from '../../api/clusters';
-import useApi from '../../api/useApi';
 import { ResourceUIState } from '../../types';
 import { DiscoveryImageModalButton } from './discoveryImageModal';
+import { selectCurrentClusterUIState } from '../../selectors/currentCluster';
 
 interface BareMetalInventoryProps {
   cluster: Cluster;
@@ -27,17 +26,7 @@ interface BareMetalInventoryProps {
 }
 
 const BaremetalInventory: React.FC<BareMetalInventoryProps> = ({ cluster, setStep }) => {
-  const [{ data: hosts, uiState }, fetchHosts] = useApi(getClusterHosts, cluster.id, {
-    manual: true,
-    initialUIState: cluster.hosts?.length ? ResourceUIState.LOADED : ResourceUIState.EMPTY,
-  });
-
-  React.useEffect(() => {
-    const timer = setTimeout(() => {
-      fetchHosts();
-    }, 5000);
-    return () => clearTimeout(timer);
-  });
+  const uiState = useSelector(selectCurrentClusterUIState);
 
   return (
     <>
@@ -59,12 +48,7 @@ const BaremetalInventory: React.FC<BareMetalInventoryProps> = ({ cluster, setSte
         </TextContent>
       </PageSection>
       <PageSection variant={PageSectionVariants.light} isMain>
-        <HostsTable
-          hosts={hosts || cluster.hosts}
-          uiState={uiState}
-          fetchHosts={fetchHosts}
-          clusterId={cluster.id}
-        />
+        <HostsTable cluster={cluster} uiState={uiState} />
       </PageSection>
       <ClusterWizardToolbar>
         <ToolbarButton
@@ -76,9 +60,6 @@ const BaremetalInventory: React.FC<BareMetalInventoryProps> = ({ cluster, setSte
           )}
         ></ToolbarButton>
         <DiscoveryImageModalButton ButtonComponent={ToolbarButton} />
-        {/* <ToolbarButton variant={ButtonVariant.secondary} onClick={() => fetchHosts()}>
-          Reload Hosts
-        </ToolbarButton> */}
         <ToolbarButton
           variant={ButtonVariant.secondary}
           onClick={() => setStep(WizardStep.ClusterConfiguration)}

--- a/src/components/clusterWizard/RoleDropdown.tsx
+++ b/src/components/clusterWizard/RoleDropdown.tsx
@@ -1,8 +1,10 @@
 import React from 'react';
+import { useDispatch } from 'react-redux';
 import { Host, ClusterUpdateParams } from '../../api/types';
 import { SimpleDropdown } from '../ui/SimpleDropdown';
 import { patchCluster } from '../../api/clusters';
 import { HostRolesType, HOST_ROLES } from '../../config/constants';
+import { updateCluster } from '../../features/clusters/currentClusterSlice';
 
 type RoleDropdownProps = {
   role: Host['role'];
@@ -11,6 +13,7 @@ type RoleDropdownProps = {
 
 export const RoleDropdown: React.FC<RoleDropdownProps> = ({ role, host }) => {
   const [isDisabled, setDisabled] = React.useState(false);
+  const dispatch = useDispatch();
 
   const setRole = async (role?: string) => {
     const params: ClusterUpdateParams = {};
@@ -21,9 +24,8 @@ export const RoleDropdown: React.FC<RoleDropdownProps> = ({ role, host }) => {
         role: role as HostRolesType,
       },
     ];
-    // TODO(mlibra): store updatedCluster (infra WIP) or initiate reload
-    // const updatedCluster =
-    await patchCluster(host.clusterId as string, params);
+    const { data } = await patchCluster(host.clusterId as string, params);
+    dispatch(updateCluster(data));
     setDisabled(false);
   };
 


### PR DESCRIPTION
Host list retrieved along cluster details is used instead.

In addition, manual passing down of parameters is removed in favour of Redux.
