### PR TITLE
Discovery iso proxy field

### DIFF
--- a/src/api/swagger.json
+++ b/src/api/swagger.json
@@ -489,6 +489,45 @@
         }
       }
     },
+    "/clusters/{clusterId}/hosts/{hostId}/progress": {
+      "put": {
+        "tags": ["inventory"],
+        "summary": "Update installation progress",
+        "operationId": "UpdateHostInstallProgress",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "clusterId",
+            "description": "The ID of the cluster to retrieve",
+            "type": "string",
+            "format": "uuid",
+            "required": true
+          },
+          {
+            "in": "path",
+            "name": "hostId",
+            "description": "The ID of the host to retrieve",
+            "type": "string",
+            "format": "uuid",
+            "required": true
+          },
+          {
+            "in": "body",
+            "name": "host-install-progress-params",
+            "description": "New progress value",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/host-install-progress-params"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Update install progress"
+          }
+        }
+      }
+    },
     "/clusters/{clusterId}/hosts/{hostId}/actions/debug": {
       "post": {
         "tags": ["inventory"],
@@ -717,16 +756,9 @@
     "image-create-params": {
       "type": "object",
       "properties": {
-        "proxyIp": {
+        "proxyURL": {
           "type": "string",
-          "format": "hostname",
-          "description": "The IP address of the HTTP proxy that agents should use to access the discovery service"
-        },
-        "proxyPort": {
-          "type": "integer",
-          "description": "The port of the HTTP proxy",
-          "minimum": 0,
-          "maximum": 65535
+          "description": "The URL of the HTTP/S proxy that agents should use to access the discovery service\nhttp://\\<user\\>:\\<password\\>@\\<server\\>:\\<port\\>/\n"
         },
         "sshPublicKey": {
           "type": "string",
@@ -790,6 +822,11 @@
               "enum": ["undefined", "master", "worker"]
             },
             "updatedAt": {
+              "type": "string",
+              "format": "date-time",
+              "x-go-custom-tag": "gorm:\"type:datetime\""
+            },
+            "createdAt": {
               "type": "string",
               "format": "date-time",
               "x-go-custom-tag": "gorm:\"type:datetime\""
@@ -897,7 +934,7 @@
     },
     "cluster-create-params": {
       "type": "object",
-      "required": ["name"],
+      "required": ["name", "openshiftVersion"],
       "properties": {
         "name": {
           "type": "string",
@@ -959,11 +996,6 @@
         "name": {
           "type": "string",
           "description": "OpenShift cluster name"
-        },
-        "openshiftVersion": {
-          "type": "string",
-          "pattern": "^4\\.\\d$",
-          "description": "OpenShift cluster version"
         },
         "baseDnsDomain": {
           "type": "string",
@@ -1094,6 +1126,9 @@
             "status": {
               "type": "string",
               "enum": ["insufficient", "ready", "error", "installing", "installed"]
+            },
+            "statusInfo": {
+              "type": "string"
             },
             "hosts": {
               "x-go-custom-tag": "gorm:\"foreignkey:ClusterID;association_foreignkey:ID\"",
@@ -1348,6 +1383,9 @@
           }
         }
       }
+    },
+    "host-install-progress-params": {
+      "type": "string"
     }
   }
 }

--- a/src/api/types.ts
+++ b/src/api/types.ts
@@ -67,6 +67,7 @@ export interface Cluster {
    */
   sshPublicKey?: string;
   status: 'insufficient' | 'ready' | 'error' | 'installing' | 'installed';
+  statusInfo?: string;
   hosts?: Host[];
   updatedAt?: string; // date-time
   createdAt?: string; // date-time
@@ -81,7 +82,7 @@ export interface ClusterCreateParams {
   /**
    * OpenShift cluster version
    */
-  openshiftVersion?: string; // ^4\.\d$
+  openshiftVersion: string; // ^4\.\d$
   /**
    * The base domain of the cluster. All DNS records must be sub-domains of this base and include the cluster name.
    */
@@ -125,10 +126,6 @@ export interface ClusterUpdateParams {
    * OpenShift cluster name
    */
   name?: string;
-  /**
-   * OpenShift cluster version
-   */
-  openshiftVersion?: string; // ^4\.\d$
   /**
    * The base domain of the cluster. All DNS records must be sub-domains of this base and include the cluster name.
    */
@@ -219,20 +216,20 @@ export interface Host {
   hardwareInfo?: string;
   role?: 'undefined' | 'master' | 'worker';
   updatedAt?: string; // date-time
+  createdAt?: string; // date-time
 }
 export interface HostCreateParams {
   hostId: string; // uuid
 }
+export type HostInstallProgressParams = string;
 export type HostList = Host[];
 export interface ImageCreateParams {
   /**
-   * The IP address of the HTTP proxy that agents should use to access the discovery service
+   * The URL of the HTTP/S proxy that agents should use to access the discovery service
+   * http://\<user\>:\<password\>@\<server\>:\<port\>/
+   *
    */
-  proxyIp?: string; // hostname
-  /**
-   * The port of the HTTP proxy
-   */
-  proxyPort?: number;
+  proxyURL?: string;
   /**
    * SSH public key for debugging the installation
    */

--- a/src/components/clusterWizard/ClusterWizardForm.tsx
+++ b/src/components/clusterWizard/ClusterWizardForm.tsx
@@ -22,14 +22,14 @@ import { useDispatch } from 'react-redux';
 import ClusterWizardToolbar from './ClusterWizardToolbar';
 import PageSection from '../ui/PageSection';
 import { ToolbarButton, ToolbarText } from '../ui/Toolbar';
-import { InputField, TextAreaField, SelectField } from '../ui/formik';
+import { InputField, TextAreaField } from '../ui/formik';
 import validationSchema from './validationSchema';
 import GridGap from '../ui/GridGap';
 import { Cluster, ClusterUpdateParams } from '../../api/types';
 import { WizardStep } from '../../types/wizard';
 import { patchCluster } from '../../api/clusters';
 import { handleApiError } from '../../api/utils';
-import { OPENSHIFT_VERSION_OPTIONS, CLUSTER_MANAGER_SITE_LINK } from '../../config/constants';
+import { CLUSTER_MANAGER_SITE_LINK } from '../../config/constants';
 import AlertsSection from '../ui/AlertsSection';
 import { updateCluster } from '../../features/clusters/currentClusterSlice';
 
@@ -43,7 +43,6 @@ const ClusterWizardForm: React.FC<ClusterWizardFormProps> = ({ cluster, setStep 
 
   const initialValues: ClusterUpdateParams = {
     name: cluster.name || '',
-    openshiftVersion: cluster.openshiftVersion || OPENSHIFT_VERSION_OPTIONS[0].value,
     baseDnsDomain: cluster.baseDnsDomain || '',
     clusterNetworkCIDR: cluster.clusterNetworkCIDR || '',
     clusterNetworkHostPrefix: cluster.clusterNetworkHostPrefix || 0,
@@ -106,13 +105,6 @@ const ClusterWizardForm: React.FC<ClusterWizardFormProps> = ({ cluster, setStep 
                       <Text component="h1">Configure a bare metal OpenShift cluster</Text>
                     </TextContent>
                     <InputField label="Cluster Name" name="name" isRequired />
-                    <SelectField
-                      label="OpenShift Version"
-                      name="openshiftVersion"
-                      options={OPENSHIFT_VERSION_OPTIONS}
-                      isDisabled
-                      isRequired
-                    />
                     <InputField
                       label="Base DNS domain"
                       name="baseDnsDomain"

--- a/src/components/clusterWizard/discoveryImageModal.tsx
+++ b/src/components/clusterWizard/discoveryImageModal.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import Axios, { CancelTokenSource } from 'axios';
+import * as Yup from 'yup';
 import {
   Modal,
   Button,
@@ -19,8 +20,8 @@ import { Formik, FormikHelpers } from 'formik';
 import { createClusterDownloadsImage, getClusterDownloadsImageUrl } from '../../api/clusters';
 import { useParams } from 'react-router-dom';
 import { LoadingState } from '../ui/uiState';
-import { ImageCreateParams } from '../../api/types';
 import { handleApiError } from '../../api/utils';
+import { ImageCreateParams } from '../../api/types';
 
 type DiscoveryImageModalButtonProps = {
   ButtonComponent?: typeof Button | typeof ToolbarButton;
@@ -42,6 +43,10 @@ export const DiscoveryImageModalButton: React.FC<DiscoveryImageModalButtonProps>
     </>
   );
 };
+
+const validationSchema = Yup.object().shape({
+  proxyURL: Yup.string().url('Provide a valid URL.'),
+});
 
 type DiscoveryImageModalProps = {
   closeModal: () => void;
@@ -86,9 +91,9 @@ export const DiscoveryImageModal: React.FC<DiscoveryImageModalProps> = ({ closeM
       isSmall
     >
       <Formik
-        initialValues={{ proxyIp: '', proxyPort: undefined, sshPublicKey: '' } as ImageCreateParams}
+        initialValues={{ proxyURL: '', sshPublicKey: '' } as ImageCreateParams}
         initialStatus={{ error: null }}
-        // validate={validate}
+        validationSchema={validationSchema}
         onSubmit={handleSubmit}
       >
         {({ handleSubmit, isSubmitting, status, setStatus }) => (
@@ -113,24 +118,21 @@ export const DiscoveryImageModal: React.FC<DiscoveryImageModalProps> = ({ closeM
                   />
                 )}
                 <TextContent>
-                  <Text component="p">
+                  <Text component="small">
                     Hosts must be connected to the internet to form a cluster using this installer.
-                    If hosts need to connect through a proxy, provide the proxy's information below.
+                    If hosts are behind a firewall that requires use of a proxy, provide proxy URL
+                    below.
                   </Text>
-                  <Text component="p">
+                  <Text component="small">
                     Each host will need a valid IP address assigned by a DHCP server with DNS
                     records that fully resolve.
                   </Text>
                 </TextContent>
                 <InputField
-                  label="Proxy IP"
-                  name="proxyIp"
-                  helperText="The IP address of the HTTP proxy that agents should use to access the discovery service"
-                />
-                <InputField
-                  label="Proxy port"
-                  name="proxyPort"
-                  helperText="The port of the HTTP proxy"
+                  label="HTTP Proxy URL"
+                  name="proxyURL"
+                  placeholder="http://<user>:<password>@<ipaddr>:<port>"
+                  helperText="HTTP proxy URL that agents should use to access the discovery service"
                 />
                 <TextAreaField
                   label="SSH public key"


### PR DESCRIPTION
- swagger and api types update
- Remove openshiftVersion from ClusterWizardForm
- Turn ISO proxy config to a single field
- add validations for discovery image form
- slightly reworded the proxy information

- [x] Depends on https://github.com/openshift-metal3/facet/pull/87

<img width="693" alt="Screenshot 2020-05-07 at 11 32 52" src="https://user-images.githubusercontent.com/1121740/81278866-90413080-9056-11ea-8ea0-3badcd24bc2a.png">
