### PR TITLE
Npm publish

### DIFF
--- a/hacks/npm-publish.sh
+++ b/hacks/npm-publish.sh
@@ -16,7 +16,8 @@ export BRANCH=rel-${VERSION}
 git checkout -b ${BRANCH}
 git push --set-upstream origin ${BRANCH} 
 git push --tags
-xdg-open https://github.com/openshift-metal3/facet/compare/${BRANCH}?expand=1
+xdg-open https://github.com/openshift-metal3/facet/compare/${BRANCH}?expand=1 # to open pull-request with version change
 
 yarn publish --non-interactive --access public
+xdg-open https://www.npmjs.com/package/metal3-facet # just because ...
 

--- a/hacks/npm-publish.sh
+++ b/hacks/npm-publish.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+set -ex
+
+export TMPDIR=`mktemp -d /tmp/XXXX`
+cd ${TMPDIR}
+
+git clone https://github.com/openshift-metal3/facet.git
+cd facet
+pwd
+
+yarn version --patch
+export VERSION=`git log -1 --pretty=%B`
+
+export BRANCH=rel-${VERSION}
+git checkout -b ${BRANCH}
+git push --set-upstream origin ${BRANCH} 
+git push --tags
+xdg-open https://github.com/openshift-metal3/facet/compare/${BRANCH}?expand=1
+
+yarn publish --non-interactive --access public
+

--- a/package.json
+++ b/package.json
@@ -1,7 +1,12 @@
 {
   "name": "metal3-facet",
   "version": "0.1.2",
-  "private": true,
+  "private": false,
+  "license": "Apache-2.0",
+  "bugs": {
+    "url": "https://github.com/openshift-metal3/facet/issues"
+  },
+  "homepage": "https://github.com/openshift-metal3/facet",
   "dependencies": {
     "@patternfly/patternfly": "^2.68.4",
     "@patternfly/react-core": "^3.146.0",


### PR DESCRIPTION
The `package.json` is updated for metadata to allow NPM-package publishing.

New `hack/npm-publish.sh` script is provided to manually trigger package version increase and publishing it to NPM repository.

To run this script, the user needs to
- have permissions to create branches under `https://github.com/openshift-metal3/facet`
- be logged to npmjs.com (via `yarn login`)

Intentionally, we do not want to automate publishing of the package but trigger it manually instead.