### PR TITLE
Host installation progress tracking

### DIFF
--- a/src/components/clusterConfiguration/HostStatus.css
+++ b/src/components/clusterConfiguration/HostStatus.css
@@ -1,0 +1,4 @@
+.host-status__button {
+  /* condensed table does not take button sizes into account */
+  font-size: var(--pf-c-table-cell--FontSize) !important;
+}

--- a/src/components/clusterConfiguration/HostStatus.tsx
+++ b/src/components/clusterConfiguration/HostStatus.tsx
@@ -2,57 +2,96 @@ import React from 'react';
 import { Popover, Button, ButtonVariant } from '@patternfly/react-core';
 import {
   global_danger_color_100 as dangerColor,
+  global_warning_color_100 as warningColor,
   global_success_color_200 as okColor,
 } from '@patternfly/react-tokens';
-import { ExclamationCircleIcon, CheckCircleIcon } from '@patternfly/react-icons';
+import {
+  ExclamationCircleIcon,
+  CheckCircleIcon,
+  WarningTriangleIcon,
+  InProgressIcon,
+  DisconnectedIcon,
+  ConnectedIcon,
+  OffIcon,
+  UnknownIcon,
+} from '@patternfly/react-icons';
+import { Host } from '../../api/types';
+import HostProgress from '../clusterDetail/HostProgress';
+import { HOST_STATUS_LABELS } from '../../config/constants';
 
-type HostStatus =
-  | 'discovering'
-  | 'known'
-  | 'disconnected'
-  | 'insufficient'
-  | 'disabled'
-  | 'installing'
-  | 'installed'
-  | 'error';
+import './HostStatus.css';
 
-const statusTitles = {
-  discovering: 'Discovering',
-  known: 'Known',
-  disconnected: 'Disconnected',
-  insufficient: 'Insufficient',
-  disabled: 'Disabled',
-  installing: 'Installing',
-  installed: 'Installed',
-  error: 'Error',
-};
-
-const getStatusIcon = (status: HostStatus) => {
-  if (status === 'insufficient') return <ExclamationCircleIcon color={dangerColor.value} />;
+const getStatusIcon = (status: Host['status']) => {
+  if (status === 'discovering') return <ConnectedIcon />;
   if (status === 'known') return <CheckCircleIcon color={okColor.value} />;
-  return null;
+  if (status === 'disconnected') return <DisconnectedIcon />;
+  if (status === 'disabled') return <OffIcon />;
+  if (status === 'insufficient') return <WarningTriangleIcon color={warningColor.value} />;
+  if (status === 'installing') return <InProgressIcon />;
+  if (status === 'error') return <ExclamationCircleIcon color={dangerColor.value} />;
+  if (status === 'installed') return <CheckCircleIcon color={okColor.value} />;
+  return <UnknownIcon />;
 };
 
 type HostStatusProps = {
-  status: HostStatus;
+  status: Host['status'];
   statusInfo?: string;
+  // progressInfo?: Host['progressInfo'] // TODO(jtomasek): enable this once progressInfo is available
+  progressInfo?: {
+    steps: string[];
+    currentStep: string;
+  };
 };
 
 const HostStatus: React.FC<HostStatusProps> = ({ status, statusInfo }) => {
-  const title = statusTitles[status] || status;
+  const title = HOST_STATUS_LABELS[status] || status;
   const icon = getStatusIcon(status);
-  if (statusInfo) {
-    return (
-      <Popover headerContent={<div>{title}</div>} bodyContent={<div>{statusInfo}</div>}>
-        <Button variant={ButtonVariant.link} isInline>
-          {icon} {title}
-        </Button>
-      </Popover>
-    );
-  }
+
+  // TODO(jtomasek): mocked steps, remove when progressInfo is available
+  const installationSteps = [
+    'Starting installation',
+    'Installing as <node role>',
+    'Writing image to disk',
+    'Rebooting',
+  ];
+  const progressInfo = {
+    steps: installationSteps,
+    currentStep: 'Writing image to disk' || 'Starting Installation',
+  };
+
+  const currentStepNumber = progressInfo.steps.indexOf(progressInfo.currentStep) + 1;
+  const headerContent = React.useMemo(() => <div>{title}</div>, [title]);
+  const bodyContent = React.useMemo(
+    () => (
+      <div>
+        {['installing', 'error', 'installed'].includes(status) && (
+          <>
+            <HostProgress status={status} progressInfo={progressInfo} />
+            <br />
+          </>
+        )}
+        {statusInfo}
+      </div>
+    ),
+    [status, statusInfo, progressInfo],
+  );
   return (
     <>
-      {icon} {title}
+      <Popover
+        headerContent={headerContent}
+        bodyContent={bodyContent}
+        minWidth="30rem"
+        maxWidth="50rem"
+      >
+        <Button variant={ButtonVariant.link} className="host-status__button" isInline>
+          {icon} {title}{' '}
+          {['installing', 'error'].includes(status) && (
+            <>
+              {currentStepNumber}/{progressInfo.steps.length}
+            </>
+          )}
+        </Button>
+      </Popover>
     </>
   );
 };

--- a/src/components/clusterConfiguration/HostsTable.tsx
+++ b/src/components/clusterConfiguration/HostsTable.tsx
@@ -41,13 +41,8 @@ type OpenRows = {
 };
 
 const columns = [
-  {
-    title: 'ID',
-    cellFormatters: [expandable],
-    transforms: [sortable],
-  },
+  { title: 'Serial Number', transforms: [sortable], cellFormatters: [expandable] },
   { title: 'Role', transforms: [sortable] },
-  { title: 'Serial Number', transforms: [sortable] },
   { title: 'Status', transforms: [sortable] },
   { title: 'Created At', transforms: [sortable] },
   { title: 'CPU Cores', transforms: [sortable] }, // cores per machine (sockets x cores)
@@ -75,7 +70,6 @@ const hostToHostTableRow = (openRows: OpenRows) => (host: Host, idx: number): IR
           title: roleCellTitle,
           sortableValue: role,
         },
-        id, // TODO(mlibra): should be serial number
         {
           title: <HostStatus status={status} statusInfo={statusInfo} />,
           sortableValue: status,
@@ -105,7 +99,7 @@ const HostsTableEmptyState: React.FC = () => (
   />
 );
 
-const rowKey = ({ rowData }: ExtraParamsType) => rowData?.id?.title;
+const rowKey = ({ rowData }: ExtraParamsType) => rowData?.['serial-number']?.title;
 
 const HostsTable: React.FC<HostsTableProps> = ({ cluster }) => {
   const [openRows, setOpenRows] = React.useState({} as OpenRows);

--- a/src/components/clusterDetail/HostProgress.tsx
+++ b/src/components/clusterDetail/HostProgress.tsx
@@ -1,0 +1,52 @@
+import React from 'react';
+import { Host } from '../../api/types';
+import {
+  Progress,
+  ProgressVariant,
+  ProgressMeasureLocation,
+  ProgressSize,
+} from '@patternfly/react-core';
+
+const getProgressVariant = (status: Host['status']) => {
+  switch (status) {
+    case 'error':
+      return ProgressVariant.danger;
+    case 'installed':
+      return ProgressVariant.success;
+    default:
+      return ProgressVariant.info;
+  }
+};
+
+const getMeasureLocation = (status: Host['status']) =>
+  status === 'installed' ? ProgressMeasureLocation.none : ProgressMeasureLocation.top;
+
+type HostProgressProps = {
+  status: Host['status'];
+  // progressInfo: Host['progressInfo']; // TODO(jtomasek) replace this once progressInfo is available
+  progressInfo: {
+    steps: string[];
+    currentStep: string;
+  };
+};
+
+const HostProgress: React.FC<HostProgressProps> = ({ status, progressInfo }) => {
+  const { steps, currentStep } = progressInfo;
+  const currentStepNumber = steps.indexOf(currentStep) + 1;
+
+  return (
+    <Progress
+      title={status === 'installed' ? 'Finished' : currentStep}
+      value={currentStepNumber}
+      min={1}
+      max={steps.length}
+      label={`Step ${currentStepNumber} of ${steps.length}`}
+      valueText={`Step ${currentStepNumber} of ${steps.length}: ${currentStep}`}
+      variant={getProgressVariant(status)}
+      measureLocation={getMeasureLocation(status)}
+      size={ProgressSize.sm}
+    />
+  );
+};
+
+export default HostProgress;

--- a/src/config/constants.ts
+++ b/src/config/constants.ts
@@ -1,4 +1,4 @@
-import { ClusterCreateParams, Cluster } from '../api/types';
+import { ClusterCreateParams, Cluster, Host } from '../api/types';
 
 type OpenshiftVersionOptionType = {
   label: string;
@@ -26,4 +26,15 @@ export const CLUSTER_STATUS_LABELS: { [key in Cluster['status']]: string } = {
   installing: 'Installing',
   error: 'Error',
   installed: 'Installed',
+};
+
+export const HOST_STATUS_LABELS: { [key in Host['status']]: string } = {
+  discovering: 'Discovering',
+  known: 'Known',
+  disconnected: 'Disconnected',
+  insufficient: 'Insufficient',
+  disabled: 'Disabled',
+  installing: 'Installing',
+  installed: 'Installed',
+  error: 'Error',
 };


### PR DESCRIPTION
- [x] depends on #122 

- Add ClusterStatus to clusters table
- Reword install action button 
- Track installation progress for each host in HostStatus and HostPopover