### PR TITLE
Fix ClusterConfiguration validation

### DIFF
--- a/src/components/clusterConfiguration/ClusterConfiguration.tsx
+++ b/src/components/clusterConfiguration/ClusterConfiguration.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import _ from 'lodash';
 import { Formik, FormikHelpers, FormikProps } from 'formik';
 import * as Yup from 'yup';
 import { Link } from 'react-router-dom';
@@ -127,6 +128,8 @@ const ClusterConfiguration: React.FC<ClusterConfigurationProps> = ({ cluster }) 
       initialStatus={{ error: null }}
       validationSchema={validationSchema}
       onSubmit={handleSubmit}
+      initialTouched={_.mapValues(initialValues, () => true)}
+      validateOnMount
     >
       {({
         setStatus,


### PR DESCRIPTION
There is a possibility that a cluster is created with invalid value.
e.g. via API. This change touches all fields and validates on mount
to catch any incorrectly configured fields right after the form is
mounted