### PR TITLE
Add loading and empty state for events

### DIFF
--- a/src/components/fetching/EventListFetch.tsx
+++ b/src/components/fetching/EventListFetch.tsx
@@ -3,7 +3,7 @@ import EventsList from '../ui/EventsList';
 import { EventList, Event } from '../../api/types';
 import { getEvents } from '../../api/events';
 import { POLLING_INTERVAL } from '../../config/constants';
-import { ErrorState } from '../ui/uiState';
+import { ErrorState, LoadingState } from '../ui/uiState';
 
 export type EventFetchProps = {
   entityId: Event['entityId'];
@@ -14,7 +14,7 @@ type EventListFetchProps = EventFetchProps & {
 };
 
 const EventListFetch: React.FC<EventListFetchProps> = ({ entityId, entityKind }) => {
-  const [events, setEvents] = useState<EventList>([]);
+  const [events, setEvents] = useState<EventList>();
   const [lastPolling, setLastPolling] = useState(0);
   const [error, setError] = useState('');
 
@@ -39,11 +39,15 @@ const EventListFetch: React.FC<EventListFetchProps> = ({ entityId, entityKind })
     setLastPolling(Date.now());
   }, [setLastPolling]);
 
-  return error ? (
-    <ErrorState title={error} fetchData={forceRefetch} />
-  ) : (
-    <EventsList events={events} />
-  );
+  if (error) {
+    return <ErrorState title={error} fetchData={forceRefetch} />;
+  }
+
+  if (!events) {
+    return <LoadingState />;
+  }
+
+  return <EventsList events={events} />;
 };
 
 export default EventListFetch;

--- a/src/components/ui/EventsList.tsx
+++ b/src/components/ui/EventsList.tsx
@@ -3,7 +3,7 @@ import hdate from 'human-date';
 import { EventList } from '../../api/types';
 import { TableVariant, Table, TableBody } from '@patternfly/react-table';
 import { ExtraParamsType } from '@patternfly/react-table/dist/js/components/Table/base';
-import { fitContent } from '../ui/table/wrappable';
+import { fitContent, noPadding } from '../ui/table/wrappable';
 import { Tooltip, TooltipPosition } from '@patternfly/react-core';
 import { getHumanizedDateTime } from './utils';
 
@@ -16,7 +16,7 @@ type EventsListProps = {
 
 const EventsList: React.FC<EventsListProps> = ({ events }) => {
   if (events.length === 0) {
-    return null;
+    return <div>No events</div>;
   }
   // Do not memoize result to keep it recomputed since we use "relative" time bellow
   const sortedEvents = events
@@ -47,7 +47,7 @@ const EventsList: React.FC<EventsListProps> = ({ events }) => {
   return (
     <Table
       rows={rows}
-      cells={[{ title: 'Time', cellTransforms: [fitContent] }, { title: 'Message' }]}
+      cells={[{ title: 'Time', cellTransforms: [fitContent, noPadding] }, { title: 'Message' }]}
       variant={TableVariant.compact}
       aria-label="Host's disks table"
       borders={false}

--- a/src/components/ui/table/wrappable.css
+++ b/src/components/ui/table/wrappable.css
@@ -1,0 +1,3 @@
+.table-no-padding {
+  --pf-c-table-cell--PaddingLeft: 0 !important;
+};

--- a/src/components/ui/table/wrappable.ts
+++ b/src/components/ui/table/wrappable.ts
@@ -2,6 +2,8 @@
 // when available
 import { ITransform } from '@patternfly/react-table';
 
+import './wrappable.css';
+
 export const breakWord: ITransform = () => ({
   className: 'pf-m-break-word',
 });
@@ -20,4 +22,8 @@ export const truncate: ITransform = () => ({
 
 export const wrappable: ITransform = () => ({
   className: 'pf-m-wrap',
+});
+
+export const noPadding: ITransform = () => ({
+  className: 'table-no-padding',
 });


### PR DESCRIPTION
Before - host events are empty with no explanation, cluster events have padding on left side
![Screenshot from 2020-05-29 14-44-09](https://user-images.githubusercontent.com/2078045/83260941-e3705400-a1ba-11ea-8c41-c632b1d6d9e4.png)

After - show `No events` when there are none, remove cluster events padding
![Screenshot from 2020-05-29 14-43-47](https://user-images.githubusercontent.com/2078045/83260945-e4a18100-a1ba-11ea-83f4-7b87bcebe47f.png)
