### PR TITLE
Allow rootless podman build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
-FROM bitnami/nginx:1.17
+FROM nginx:1.17
 
 COPY deploy/deploy_config.sh /deploy/
 COPY deploy/ocp-metal-ui-template.yaml /deploy/
 
-COPY build/ /app/
+COPY build/ /usr/share/nginx/html/
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,5 @@
-FROM nginx:1.17
+FROM bitnami/nginx:1.17
 
 COPY build/ /usr/share/nginx/html
-RUN mkdir /deploy
-COPY deploy/deploy_config.sh /deploy
-COPY deploy/ocp-metal-ui-template.yaml /deploy
+COPY deploy/deploy_config.sh /deploy/
+COPY deploy/ocp-metal-ui-template.yaml /deploy/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,7 @@
 FROM bitnami/nginx:1.17
 
-COPY build/ /app/
 COPY deploy/deploy_config.sh /deploy/
 COPY deploy/ocp-metal-ui-template.yaml /deploy/
+
+COPY build/ /app/
+

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 FROM bitnami/nginx:1.17
 
-COPY build/ /usr/share/nginx/html
+COPY build/ /app/
 COPY deploy/deploy_config.sh /deploy/
 COPY deploy/ocp-metal-ui-template.yaml /deploy/

--- a/Makefile
+++ b/Makefile
@@ -10,10 +10,10 @@ all: build deploy
 
 build:
 	yarn build
-	sudo podman build -t $(IMAGE) .
-	sudo podman build -f Dockerfile.cypress -t $(TESTS_IMAGE) .
-	sudo podman push $(IMAGE)
-	sudo podman push $(TESTS_IMAGE)
+	podman build -t $(IMAGE) .
+	podman build -f Dockerfile.cypress -t $(TESTS_IMAGE) .
+	podman push $(IMAGE)
+	podman push $(TESTS_IMAGE)
 
 deploy:
 	mkdir -p build/deploy/

--- a/deploy/ocp-metal-ui-template.yaml
+++ b/deploy/ocp-metal-ui-template.yaml
@@ -6,8 +6,8 @@ metadata:
 spec:
   type: LoadBalancer
   ports:
-    - port: 80
-      targetPort: 80
+    - port: 8080
+      targetPort: 8080
       protocol: TCP
       # nodePort: 31000
   selector:
@@ -21,7 +21,7 @@ metadata:
 data:
   nginx.conf: |
     server {
-        listen 80;
+        listen 8080;
         server_name _;
 
         root /usr/share/nginx/html;
@@ -61,7 +61,7 @@ spec:
           image: __IMAGE__
           imagePullPolicy: Always
           ports:
-            - containerPort: 80
+            - containerPort: 8080
           volumeMounts:
             - mountPath: /etc/nginx/conf.d # mount nginx-conf volumn to /etc/nginx/conf.d
               readOnly: true


### PR DESCRIPTION
Intentionally keeping the `1.17` version (latest is `1.18`), will be upgraded later to mitigate risks for now.