### PR TITLE
Pass error title to alert component

### DIFF
--- a/src/components/clusters/newClusterModal.tsx
+++ b/src/components/clusters/newClusterModal.tsx
@@ -115,7 +115,7 @@ export const NewClusterModal: React.FC<NewClusterModalProps> = ({ closeModal }) 
             {status.error && (
               <Alert
                 variant={AlertVariant.danger}
-                title={status.error}
+                title={status.error.title}
                 action={<AlertActionCloseButton onClose={() => setStatus({ error: null })} />}
                 isInline
               >


### PR DESCRIPTION
If error occurs, passing the whole `status.error`, which is an object, fails the Alert component rendering