### PR TITLE
Rename 'Create Cluster' button to 'Install Cluster'

### DIFF
--- a/src/components/clusterConfiguration/ClusterConfiguration.tsx
+++ b/src/components/clusterConfiguration/ClusterConfiguration.tsx
@@ -375,7 +375,7 @@ const ClusterConfiguration: React.FC<ClusterConfigurationProps> = ({ cluster }) 
                 onClick={handleSubmitButtonClick}
                 isDisabled={isSubmitting || !isValid}
               >
-                Create Cluster
+                Install Cluster
               </ToolbarButton>
               <ToolbarButton
                 type="submit"


### PR DESCRIPTION
The button is currently easy to confuse with the 'Create New Cluster' button