### PR TITLE
Bare Metal Inventory text tweaks

### DIFF
--- a/src/components/clusterConfiguration/BaremetalInventory.tsx
+++ b/src/components/clusterConfiguration/BaremetalInventory.tsx
@@ -18,7 +18,12 @@ const BaremetalInventory: React.FC<BareMetalInventoryProps> = ({ cluster }) => {
         </Text>
         <Text component="p">
           Boot the discovery ISO on hardware that should become part of this bare metal cluster.
-          Hosts connected to the internet will automatically appear below.
+          Hosts connected to the internet will be inspected and automatically appear below.
+        </Text>
+        <Text component="p">
+          Three master hosts are required with at least 4 CPU cores, 16 GB of RAM, and 120 GB of
+          filesystem storage each. Two or more additional worker hosts are recommended with at least
+          2 CPU cores, 8 GB of RAM, and 120 GB of filesystem storage each.
         </Text>
       </TextContent>
       <HostsTable cluster={cluster} />

--- a/src/components/hosts/HostsTable.tsx
+++ b/src/components/hosts/HostsTable.tsx
@@ -93,7 +93,7 @@ const HostsTableEmptyState: React.FC<{ cluster: Cluster }> = ({ cluster }) => (
   <EmptyState
     icon={ConnectedIcon}
     title="Waiting for hosts..."
-    content="Boot the discovery ISO on a hardware that should become part of this bare metal cluster. After booting the ISO the hosts get inspected and register to the cluster. At least 3 bare metal hosts are required to form the cluster."
+    content="Boot the discovery ISO on hardware that should become part of this bare metal cluster. Hosts may take a few minutes after to appear here after booting."
     primaryAction={<DiscoveryImageModalButton imageInfo={cluster.imageInfo} />}
   />
 );


### PR DESCRIPTION
Adjusts some wording and adds two sentences to describe the minimum master/worker requirements for Milestone 1 until we can do something fancy like the `Workload capacity` section of the [design doc](https://docs.google.com/document/d/1OtAqrwa8dZYFp1jF8oBZ72wb3OqmjAgqvTgckXTE_qo/edit#heading=h.wio8v3zaezqa).

### Before
![image](https://user-images.githubusercontent.com/9122899/84084149-e9cbb080-a9b0-11ea-9b21-a4699ce6bdfb.png)

### After
![image](https://user-images.githubusercontent.com/9122899/84084166-f18b5500-a9b0-11ea-8f77-0259350a24ad.png)