### PR TITLE
Embolden Discovery ISO modal text 

### DIFF
--- a/src/components/clusterConfiguration/discoveryImageModal.tsx
+++ b/src/components/clusterConfiguration/discoveryImageModal.tsx
@@ -134,8 +134,8 @@ export const DiscoveryImageModal: React.FC<DiscoveryImageModalProps> = ({
                 <TextContent>
                   <Text component="p">
                     Hosts must be connected to the internet to form a cluster using this installer.
-                    If hosts are behind a firewall that requires use of a proxy, provide proxy URL
-                    below.
+                    If hosts are behind a firewall that requires the use of a proxy, provide the
+                    proxy URL below.
                   </Text>
                   <Text component="p">
                     Each host will need a valid IP address assigned by a DHCP server with DNS

--- a/src/components/clusterConfiguration/discoveryImageModal.tsx
+++ b/src/components/clusterConfiguration/discoveryImageModal.tsx
@@ -132,12 +132,12 @@ export const DiscoveryImageModal: React.FC<DiscoveryImageModalProps> = ({
                   </Alert>
                 )}
                 <TextContent>
-                  <Text component="small">
+                  <Text component="p">
                     Hosts must be connected to the internet to form a cluster using this installer.
                     If hosts are behind a firewall that requires use of a proxy, provide proxy URL
                     below.
                   </Text>
-                  <Text component="small">
+                  <Text component="p">
                     Each host will need a valid IP address assigned by a DHCP server with DNS
                     records that fully resolve.
                   </Text>


### PR DESCRIPTION
Gives the two `<small>` tags in the Discovery ISO modal a confidence boost to become `<p>`s instead.

Edit: also includes a small grammar tweak of the second sentence.

### Before
![image](https://user-images.githubusercontent.com/9122899/84101582-485a5400-a9dc-11ea-99a1-19eb7580dff6.png)

### After
![image](https://user-images.githubusercontent.com/9122899/84101987-3af19980-a9dd-11ea-90cf-384ab1fd90a6.png)