### PR TITLE
Update title

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -22,7 +22,7 @@
       work correctly both with client-side routing and a non-root public URL.
       Learn how to configure a non-root public URL by running `npm run build`.
     -->
-    <title>Facet|Metal&sup3;</title>
+    <title>OpenShift Assisted Installer</title>
   </head>
   <body>
     <noscript>You need to enable JavaScript to run this app.</noscript>


### PR DESCRIPTION
This pairs well with the recent `favicon.ico` change of #195. 👌

`OpenShift Assisted Bare Metal Installer` might be more technically correct today, but since we're currently the only "Assisted Installer" out there we may not need the extra two words. If we eventually create a logo for this, adding "Bare Metal" might also make it pretty long. Thoughts?

### Before

![image](https://user-images.githubusercontent.com/9122899/84213571-050ced80-aa8f-11ea-9b19-54a6e68a61b3.png)

### After

![image](https://user-images.githubusercontent.com/9122899/84213531-f0c8f080-aa8e-11ea-8152-5399c4752980.png)

### Alternative

![image](https://user-images.githubusercontent.com/9122899/84213933-f07d2500-aa8f-11ea-8eb5-4b215a8a6d52.png)