### PR TITLE
Expose UI version

### DIFF
--- a/.env.development
+++ b/.env.development
@@ -1,1 +1,2 @@
 REACT_APP_API_URL=http://REACT_APP_API_URL.env.variable.not:set
+REACT_APP_VERSION='0.0.0-dev'

--- a/.github/workflows/buildAndPush.yaml
+++ b/.github/workflows/buildAndPush.yaml
@@ -19,10 +19,15 @@ jobs:
         uses: borales/actions-yarn@v2.0.0
         with:
           cmd: lint
+      - name: Get tag
+        id: get_tag
+        run: echo ::set-env name=GIT_TAG::${GITHUB_REF/refs\/tags\//}
       - name: Build code
         uses: borales/actions-yarn@v2.0.0
         env:
           NODE_OPTIONS: '--max-old-space-size=8192'
+          REACT_APP_GIT_SHA: ${{ github.sha }}
+          REACT_APP_VERSION: ${{ env.GIT_TAG }}
         with:
           cmd: build
       - name: Publish to quay.io

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -3,7 +3,7 @@ name: Build and push
 on:
   push:
     tags:
-      - "*"
+      - '*'
 
 jobs:
   build:
@@ -19,15 +19,17 @@ jobs:
         uses: borales/actions-yarn@v2.0.0
         with:
           cmd: lint
+      - name: Get tag
+        id: get_tag
+        run: echo ::set-env name=GIT_TAG::${GITHUB_REF/refs\/tags\//}
       - name: Build code
         uses: borales/actions-yarn@v2.0.0
         env:
           NODE_OPTIONS: '--max-old-space-size=8192'
+          REACT_APP_GIT_SHA: ${{ github.sha }}
+          REACT_APP_VERSION: ${{ env.GIT_TAG }}
         with:
           cmd: build
-      - name: Get tag
-        id: get_tag
-        run: echo ::set-env name=GIT_TAG::${GITHUB_REF/refs\/tags\//}
       - name: Publish to quay.io
         uses: elgohr/Publish-Docker-Github-Action@2.14
         with:

--- a/src/components/ui/Header.tsx
+++ b/src/components/ui/Header.tsx
@@ -4,6 +4,7 @@ import metal3FacetLogo from '../../images/metal3_facet-whitetext.png';
 import redhatLogo from '../../images/Logo-Red_Hat-OpenShift_Container_Platform-B-Reverse-RGB.png';
 import { getProductBrandingCode, FEEDBACK_FORM_LINK } from '../../config/constants';
 import { ExternalLinkAltIcon } from '@patternfly/react-icons';
+import { VERSION } from '../../config/standalone';
 
 const getBrandingDetails = () => {
   switch (getProductBrandingCode()) {
@@ -37,6 +38,7 @@ const Header: React.FC = () => {
           >
             Provide feedback <ExternalLinkAltIcon />
           </Button>
+          {VERSION}
         </PageHeaderTools>
       }
       // toolbar={PageToolbar}

--- a/src/config/standalone.ts
+++ b/src/config/standalone.ts
@@ -1,0 +1,2 @@
+export const VERSION = process.env.REACT_APP_VERSION;
+export const GIT_SHA = process.env.REACT_APP_GIT_SHA;


### PR DESCRIPTION
Use latest git tag and git sha exposed to the UI on build time via environment
variables. Display the UI version in the masthead.