### PR TITLE
Image tages - :stable vs. latest:

### DIFF
--- a/.github/workflows/mergeToMaster.yaml
+++ b/.github/workflows/mergeToMaster.yaml
@@ -38,7 +38,7 @@ jobs:
           password: ${{ secrets.QUAYIO_OCPMETAL_PASSWORD }}
           registry: quay.io
           dockerfile: Dockerfile
-          tags: 'latestdev,${{ github.sha }}'
+          tags: 'latest,${{ github.sha }}'
       - name: Publish integration tests to quay.io
         uses: elgohr/Publish-Docker-Github-Action@2.14
         with:
@@ -47,4 +47,4 @@ jobs:
           password: ${{ secrets.QUAYIO_OCPMETAL_PASSWORD }}
           registry: quay.io
           dockerfile: Dockerfile.cypress
-          tags: 'latestdev,${{ github.sha }}'
+          tags: 'latest,${{ github.sha }}'

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -38,7 +38,7 @@ jobs:
           password: ${{ secrets.QUAYIO_OCPMETAL_PASSWORD }}
           registry: quay.io
           dockerfile: Dockerfile
-          tags: 'latest,${{ env.GIT_TAG }},${{ github.sha }}'
+          tags: 'stable,${{ env.GIT_TAG }},${{ github.sha }}'
       - name: Publish integration tests to quay.io
         uses: elgohr/Publish-Docker-Github-Action@2.14
         with:
@@ -47,4 +47,4 @@ jobs:
           password: ${{ secrets.QUAYIO_OCPMETAL_PASSWORD }}
           registry: quay.io
           dockerfile: Dockerfile.cypress
-          tags: 'latest,${{ env.GIT_TAG }},${{ github.sha }}'
+          tags: 'stable,${{ env.GIT_TAG }},${{ github.sha }}'


### PR DESCRIPTION
Image tags recently used:
- `:latest` ( + `:[SHA]` ) is for "development" builds, means on merge to master, not stable
- `:stable` ( + `:[SHA]` , `:[TAG]` ) is for tagged (released) versions, those intended for "production"