### PR TITLE
QE E2E

### DIFF
--- a/cypress.json
+++ b/cypress.json
@@ -3,6 +3,12 @@
   "viewportWidth": 1440,
   "viewportHeight": 1080,
   "env": {
-    "PULL_SECRET": "{}"
+    "PULL_SECRET": "{}",
+    "SSH_PUB_KEY": "",
+    "DNS_DOMAIN_NAME": "redhat.com",
+    "API_VIP": "192.168.126.100",
+    "INGRESS_VIP": "192.168.126.101",
+    "NUM_MASTERS": 3,
+    "NUM_WORKERS": 0
   }
 }

--- a/cypress/integration-qe/e2e-createNewCluster.spec.js
+++ b/cypress/integration-qe/e2e-createNewCluster.spec.js
@@ -1,0 +1,17 @@
+import { CLUSTER_NAME, PULL_SECRET, SSH_PUB_KEY, createCluster, generateIso } from './shared';
+
+describe('Flow', () => {
+  it('start from the /clusters page', () => {
+    // Set CYPRESS_BASE_URL environemnt variable
+    // Example: export CYPRESS_BASE_URL=http://localhost:3000
+    cy.visit('');
+  });
+
+  it('create a cluster named ' + CLUSTER_NAME, () => {
+    createCluster(CLUSTER_NAME, PULL_SECRET);
+  });
+
+  it('generate the ISO', () => {
+    generateIso(SSH_PUB_KEY);
+  });
+});

--- a/cypress/integration-qe/e2e-enterClusterSpecs.spec.js
+++ b/cypress/integration-qe/e2e-enterClusterSpecs.spec.js
@@ -1,0 +1,106 @@
+import {
+  CLUSTER_NAME,
+  DNS_DOMAIN_NAME,
+  API_VIP,
+  INGRESS_VIP,
+  NUM_MASTERS,
+  NUM_WORKERS,
+  hostDetailSelector,
+  openCluster,
+  startClusterInstallation,
+  waitForClusterInstallation,
+} from './shared';
+
+import {
+  HOST_REGISTRATION_TIMEOUT,
+  HOST_DISCOVERY_TIMEOUT,
+  VALIDATE_CHANGES_TIMEOUT,
+} from './constants';
+
+describe('Enter cluster details', () => {
+  it('can open the cluster details', () => {
+    openCluster(CLUSTER_NAME);
+  });
+
+  it('wait for the hosts table to be populated', () => {
+    cy.get('table.hosts-table > tbody', { timeout: HOST_REGISTRATION_TIMEOUT }).should(($els) => {
+      expect($els.length).to.be.eq(NUM_MASTERS + NUM_WORKERS);
+    });
+  });
+
+  it('wait for the subnets options to be populated', () => {
+    cy.get('#form-input-hostSubnet-field')
+      .find('option', { timeout: HOST_DISCOVERY_TIMEOUT })
+      .should(($els) => {
+        expect($els.length).to.be.gt(0);
+      })
+      .and(($els) => {
+        expect($els[0]).not.to.have.text('No subnets available');
+      });
+  });
+
+  it('wait for all hosts to reach pending input state', () => {
+    for (let i = 2; i <= NUM_MASTERS + NUM_WORKERS + 1; i++) {
+      cy.contains(hostDetailSelector(i, 'Status'), 'Pending input', {
+        timeout: HOST_DISCOVERY_TIMEOUT,
+      });
+    }
+  });
+
+  it('can set the base domain name', () => {
+    // Cluster configuration - base domain
+    cy.get('#form-input-baseDnsDomain-field').clear();
+    cy.get('#form-input-baseDnsDomain-field').type(DNS_DOMAIN_NAME);
+    cy.get('#form-input-baseDnsDomain-field').should('have.value', DNS_DOMAIN_NAME);
+  });
+
+  it('can select the first subnet CIDR', () => {
+    cy.get('#form-input-hostSubnet-field')
+      .find('option')
+      .then(($els) => $els.get(0).setAttribute('selected', 'selected'))
+      .parent()
+      .trigger('change');
+  });
+
+  it('can set API VIP', () => {
+    cy.get('#form-input-apiVip-field').clear();
+    cy.get('#form-input-apiVip-field').type(API_VIP);
+  });
+
+  it('can set ingress VIP', () => {
+    cy.get('#form-input-ingressVip-field').clear();
+    cy.get('#form-input-ingressVip-field').type(INGRESS_VIP);
+  });
+
+  it('can save cluster details', () => {
+    cy.get('button[name="save"]', { timeout: VALIDATE_CHANGES_TIMEOUT }).should(($elem) => {
+      expect($elem).to.be.enabled;
+    });
+    cy.get('button[name="save"]').click();
+  });
+});
+
+describe('Set roles', () => {
+  it('set the masters', () => {
+    cy.get('#form-input-name-field').click().type('{end}{home}');
+    for (let i = 2; i < 2 + NUM_MASTERS; i++) {
+      cy.get(hostDetailSelector(i, 'Role')).click().find('li#master').click();
+    }
+  });
+
+  it('set the workers', () => {
+    for (let i = 2 + NUM_MASTERS; i < 2 + NUM_MASTERS + NUM_WORKERS; i++) {
+      cy.get(hostDetailSelector(i, 'Role')).click().find('li#worker').click();
+    }
+  });
+});
+
+describe('Run install', () => {
+  it('start installation', () => {
+    startClusterInstallation();
+  });
+
+  it('wait for cluster installation...', () => {
+    waitForClusterInstallation();
+  });
+});

--- a/cypress/integration/clusterDetail.spec.js
+++ b/cypress/integration/clusterDetail.spec.js
@@ -7,13 +7,12 @@ import {
   visitTestCluster,
   testInfraClusterHostnames,
   checkValidationMessage,
+  hostDetailSelector,
 } from './shared';
 
 const DISCOVERING_TIMEOUT = 2 * 60 * 1000; // 2 mins
 
 describe('Cluster Detail', () => {
-  const hostDetailSelector = (row, label) =>
-    `:nth-child(${row}) > :nth-child(1) > [data-label="${label}"]`;
   const hostsTableHeaderSelector = (label) => `[data-label="${label}"] > .pf-c-table__button`;
   const actualSorterSelector = '.pf-m-selected > .pf-c-table__button';
 

--- a/cypress/integration/constants.js
+++ b/cypress/integration/constants.js
@@ -1,0 +1,12 @@
+// api timeout - 10 seconds
+export const DEFAULT_API_REQUEST_TIMEOUT = 10 * 1000;
+// timeout for hosts to boot and register - 10 minutes
+export const HOST_REGISTRATION_TIMEOUT = 10 * 60 * 1000;
+// host discovery and subnet discovery timeout - 30 seconds
+export const HOST_DISCOVERY_TIMEOUT = 30 * 1000;
+// timeout for validate changes - 10 seconds
+export const VALIDATE_CHANGES_TIMEOUT = 10 * 1000;
+// timeout for install preparation - 1 minute
+export const INSTALL_PREPARATION_TIMEOUT = 60 * 1000;
+// timeout for cluster instation to finish - 1 hour
+export const CLUSTER_CREATION_TIMEOUT = 60 * 60 * 1000;


### PR DESCRIPTION
QE E2E 

These are the 2 scripts that are run by the Ansible automation:
1) The 1st script handles the creation of the cluster in the UI up until the 
   downloading of the ISO.
2) The 2nd script runs after the ISO was downloaded and the hosts booted

To prevent it from accidentally being run in other CIs, it is located in
a non-default directory. To run it: 

export CYPRESS_BASE_URL=https://...
export CYPRESS_CLUSTER_NAME=cypress
export CYPRESS_DNS_DOMAIN_NAME=qe.lab.redhat.com
export CYPRESS_API_VIP=192.168.123.5
export CYPRESS_INGRESS_VIP=192.168.123.10
export CYPRESS_SSH_PUB_KEY=$(cat ~/.ssh/id_rsa.pub)
export CYPRESS_PULL_SECRET='...'
export CYPRESS_NUM_MASTERS=3
export CYPRESS_NUM_WORKERS=2
mv cypress/integration-qe/e2e-createNewCluster.spec.js cypress/integration/
mv cypress/integration-qe/e2e-enterClusterSpecs.spec.js cypress/integration/
cypress-run --spec "cypress/integration/e2e-createNewCluster.spec.js"
// now get the ISO to the machines and boot them, then run the 2nd 
// script:
cypress-run --spec "cypress/integration/e2e-enterClusterSpecs.spec.js"
