### PR TITLE
Cancel waiting for installation in e2e scripts

### DIFF
--- a/cypress/integration-qe/e2e-enterClusterSpecs.spec.js
+++ b/cypress/integration-qe/e2e-enterClusterSpecs.spec.js
@@ -100,7 +100,7 @@ describe('Run install', () => {
     startClusterInstallation();
   });
 
-  it('wait for cluster installation...', () => {
-    waitForClusterInstallation();
-  });
+  // it('wait for cluster installation...', () => {
+  //   waitForClusterInstallation();
+  // });
 });

--- a/cypress/integration/shared.js
+++ b/cypress/integration/shared.js
@@ -180,10 +180,11 @@ export const startClusterInstallation = () => {
     expect($elem).to.be.enabled;
   });
   cy.get('button[name="install"]').click();
-  // wait for the progress description to say "Installing"
-  cy.contains('div.pf-c-progress__description', 'Installing', {
-    timeout: INSTALL_PREPARATION_TIMEOUT,
-  });
+  // wait for the progress description to say "Installing" [temporarily comented out because
+  // there is no div.pf-c-progress__description any more...]
+  // cy.contains('div.pf-c-progress__description', 'Installing', {
+  //   timeout: INSTALL_PREPARATION_TIMEOUT,
+  // });
 };
 
 export const waitForClusterInstallation = () => {


### PR DESCRIPTION
The GUI changed so temporarily we will not be able to to use Cypress
to monitor the installation progress and wait for installation to
complete.