### PR TITLE
adding utils for hosted service testing

### DIFF
--- a/cypress.json
+++ b/cypress.json
@@ -9,6 +9,10 @@
     "API_VIP": "192.168.126.100",
     "INGRESS_VIP": "192.168.126.101",
     "NUM_MASTERS": 3,
-    "NUM_WORKERS": 0
+    "NUM_WORKERS": 0,
+    "API_BASE_URL": "",
+    "INTEGRATION_ENV": "",
+    "OCM_USER": "",
+    "OCM_USER_PASSWORD": ""
   }
 }

--- a/cypress/integration-qe/basicUserAuthentication.spec.js
+++ b/cypress/integration-qe/basicUserAuthentication.spec.js
@@ -1,0 +1,18 @@
+import { verifyPullSecretHosted } from './ocmShared';
+
+describe('test basic user authentication', () => {
+  it('navigate from openshift portal to assisted installer', () => {
+    cy.visit('');
+    cy.get('[aria-current="page"]').contains('Clusters').click();
+    cy.get('button').contains('Create cluster').click();
+    cy.get('[href="/openshift/install"').click();
+    cy.get('[href="/openshift/install/metal"').click();
+    cy.get('[data-testid="ai-button"]').should('exist');
+  });
+
+  it('verify autofilled pull secret matches user pull secret', () => {
+    cy.get('[data-testid="ai-button"]').click();
+    verifyPullSecretHosted();
+    cy.get('button').contains('Cancel').click();
+  });
+});

--- a/cypress/integration/ocmShared.js
+++ b/cypress/integration/ocmShared.js
@@ -1,0 +1,68 @@
+import { makeApiCall, API_BASE_URL } from './shared';
+import { DEFAULT_API_REQUEST_TIMEOUT } from './constants';
+
+export const INTEGRATION_ENV = Cypress.env('INTEGRATION_ENV');
+export const OCM_USER = Cypress.env('OCM_USER');
+export const OCM_USER_PASSWORD = Cypress.env('OCM_USER_PASSWORD');
+
+export const loginOCM = (userName, password) => {
+  // visit ocm environemnt based on INTEGRATION_ENV (true/false)
+  // cy.visit does not direct to the correct env based on baseUrl query string
+  const visitOptions = INTEGRATION_ENV ? { qs: { env: 'integration' } } : {};
+
+  cy.visit('', visitOptions);
+  cy.get('#username').should('be.visible');
+  cy.get('#username').type(userName);
+  cy.get('#username').should('have.value', userName);
+  cy.get('#login-show-step2').click();
+  cy.get('#password').should('be.visible');
+  cy.get('#password').type(password);
+  cy.get('#password').should('have.value', password);
+  cy.get('#kc-form-login').submit();
+
+  cy.get('#button-create-new-cluster', {
+    timeout: DEFAULT_API_REQUEST_TIMEOUT,
+  });
+};
+
+// verifies auto-filled pull secret matches loged in user's pull secret
+export const verifyPullSecretHosted = () => {
+  // response handler for makeApiCall
+  const comparePullSecret = (response) => {
+    const userPullSecret = JSON.stringify(response.body);
+    cy.get('#form-input-pullSecret-field').should('have.value', userPullSecret);
+  };
+
+  makeApiCall('/api/accounts_mgmt/v1/access_token', 'post', comparePullSecret);
+};
+
+export const logOutOCM = () => {
+  cy.get('userMenu').click();
+  cy.contains('Log out').click();
+};
+
+export const loginAndPreserveEnvironment = () => {
+  before(() => {
+    cy.request({
+      method: 'GET',
+      url: `${API_BASE_URL}/api/accounts_mgmt/v1/access_token`,
+      failOnStatusCode: false,
+    }).then((response) => {
+      if (response.status === 401) {
+        loginOCM(OCM_USER, OCM_USER_PASSWORD);
+      }
+    });
+  });
+
+  beforeEach(() => {
+    // cookies and local storage are cleared between it() blocks
+    // preserving cs_jwt keeps the user logged in between tests
+    Cypress.Cookies.preserveOnce('cs_jwt');
+    // seting ocmOverridenEnvironment preserves integration/staging environments between tests
+    localStorage.setItem('ocmOverridenEnvironment', INTEGRATION_ENV ? 'integration' : '');
+  });
+
+  after(() => {
+    cy.clearCookies();
+  });
+};

--- a/cypress/integration/shared.js
+++ b/cypress/integration/shared.js
@@ -36,6 +36,7 @@ export const API_VIP = Cypress.env('API_VIP');
 export const INGRESS_VIP = Cypress.env('INGRESS_VIP');
 export const NUM_MASTERS = parseInt(Cypress.env('NUM_MASTERS'));
 export const NUM_WORKERS = parseInt(Cypress.env('NUM_WORKERS'));
+export const API_BASE_URL = Cypress.env('API_BASE_URL');
 
 // workaround for long text, expected to be copy&pasted by the user
 export const pasteText = (cy, selector, text) => {
@@ -264,4 +265,44 @@ export const saveClusterDetails = (cy) => {
   // click the 'save' button in order to save changes in the cluster info
   cy.get('button[name="save"]', { timeout: VALIDATE_CHANGES_TIMEOUT }).should('be.enabled');
   cy.get('button[name="save"]').click();
+};
+
+export const makeApiCall = (
+  apiPostfix,
+  method,
+  responseHandler,
+  requestBody = {},
+  failOnStatusCode = true,
+) => {
+  // get ocm api token from cookies
+  cy.getCookie('cs_jwt').then((cookie) => {
+    const requestOptions = {
+      method: method,
+      url: `${API_BASE_URL}${apiPostfix}`,
+      body: requestBody,
+      failOnStatusCode: failOnStatusCode,
+    };
+
+    // if token cookie is set attach to request
+    if (cookie) {
+      cy.log('using cookie');
+      requestOptions.headers = {
+        Authorization: `Bearer ${cookie.value}`,
+      };
+    }
+
+    cy.request(requestOptions).then(responseHandler);
+  });
+};
+
+export const verifyClusterCreationApi = (clusterName) => {
+  // response handler for makeApiCall
+  const findClusterInList = (response) => {
+    const clusters = response.body;
+    const checkClusterName = (cluster) => clusterName.localeCompare(cluster.name) === 0;
+
+    expect(clusters.some(checkClusterName)).to.be.true;
+  };
+
+  makeApiCall('/api/assisted-install/v1/clusters', 'get', findClusterInList);
 };

--- a/cypress/support/index.js
+++ b/cypress/support/index.js
@@ -18,3 +18,7 @@ import './commands';
 
 // Alternatively you can use CommonJS syntax:
 // require('./commands')
+
+// Login into OCM if on hosted environment
+import { loginAndPreserveEnvironment } from '../integration/ocmShared';
+loginAndPreserveEnvironment();


### PR DESCRIPTION
Added:
*function loginOCM to login to OCM environments only if LOGIN environment variable is set to true; other wise it simply visits baseUrl
*function makeApiCall that makes an API request against API_BASE_URL, if in test is in hosted environment the token is attached to request headers, otherwise no token is sent
*function verifyClusterCreationApi that verifies a cluster is created through an API call
*function verifyPullSecretHosted which verifies autofilled pull secret matches user pull secret