### PR TITLE
Restore the wait for cluster installation

### DIFF
--- a/cypress/integration-qe/e2e-enterClusterSpecs.spec.js
+++ b/cypress/integration-qe/e2e-enterClusterSpecs.spec.js
@@ -100,7 +100,7 @@ describe('Run install', () => {
     startClusterInstallation();
   });
 
-  // it('wait for cluster installation...', () => {
-  //   waitForClusterInstallation();
-  // });
+  it('wait for cluster installation...', () => {
+    waitForClusterInstallation();
+  });
 });

--- a/cypress/integration/shared.js
+++ b/cypress/integration/shared.js
@@ -191,7 +191,7 @@ export const startClusterInstallation = () => {
 
 export const waitForClusterInstallation = () => {
   // wait up to 1 hour for the progress description to say "Installed"
-  cy.contains('div.pf-c-progress__description', 'Installed', { timeout: CLUSTER_CREATION_TIMEOUT });
+  cy.contains('#cluster-progress-status-value', 'Installed', { timeout: CLUSTER_CREATION_TIMEOUT });
 };
 
 export const waitForHostTablePopulation = (cy) => {


### PR DESCRIPTION
Use Cypress to wait for the cluster installation in the E2E test