### PR TITLE
Download with Chrome

### DIFF
--- a/cypress/integration-qe/e2e-createNewCluster.spec.js
+++ b/cypress/integration-qe/e2e-createNewCluster.spec.js
@@ -1,4 +1,11 @@
-import { CLUSTER_NAME, PULL_SECRET, SSH_PUB_KEY, createCluster, generateIso } from './shared';
+import {
+  CLUSTER_NAME,
+  PULL_SECRET,
+  SSH_PUB_KEY,
+  createCluster,
+  generateIso,
+  downloadFileWithChrome,
+} from './shared';
 
 describe('Flow', () => {
   it('start from the /clusters page', () => {
@@ -13,5 +20,13 @@ describe('Flow', () => {
 
   it('generate the ISO', () => {
     generateIso(SSH_PUB_KEY);
+  });
+
+  it('download the ISO', () => {
+    cy.get('#button-download-discovery-iso').click(); // open the dialog
+    cy.get('.pf-c-modal-box__footer > .pf-m-primary').click(); // "Get Discovery ISO"
+    downloadFileWithChrome('button[data-test-id="download-iso-btn"]', ' ~/Downloads/cluster-*.iso');
+    cy.get('button[data-test-id="close-iso-btn"]').click(); // now close the dialog
+    cy.exec('mv -f ~/Downloads/cluster-*.iso /var/lib/libvirt/images/cluster-discovery.iso');
   });
 });

--- a/cypress/integration-qe/e2e-enterClusterSpecs.spec.js
+++ b/cypress/integration-qe/e2e-enterClusterSpecs.spec.js
@@ -9,6 +9,7 @@ import {
   openCluster,
   startClusterInstallation,
   waitForClusterInstallation,
+  downloadFileWithChrome,
 } from './shared';
 
 import {
@@ -102,5 +103,15 @@ describe('Run install', () => {
 
   it('wait for cluster installation...', () => {
     waitForClusterInstallation();
+  });
+});
+
+describe('Donwload kubeconfig', () => {
+  it('download kubeconfig', () => {
+    downloadFileWithChrome(
+      'div.pf-l-grid__item > button.pf-c-button.pf-m-secondary',
+      '~/Downloads/kubeconfig',
+    );
+    cy.exec('mv -f ~/Downloads/kubeconfig ~');
   });
 });

--- a/cypress/integration/constants.js
+++ b/cypress/integration/constants.js
@@ -8,5 +8,9 @@ export const HOST_DISCOVERY_TIMEOUT = 30 * 1000;
 export const VALIDATE_CHANGES_TIMEOUT = 10 * 1000;
 // timeout for install preparation - 1 minute
 export const INSTALL_PREPARATION_TIMEOUT = 60 * 1000;
+// timeout for generating ISO
+export const GENERATE_ISO_TIMEOUT = 2 * 60 * 1000;
+// timeout for downloading files (such as ISO images)
+export const FILE_DOWNLOAD_TIMEOUT = 10 * 60 * 1000;
 // timeout for cluster instation to finish - 1 hour
 export const CLUSTER_CREATION_TIMEOUT = 60 * 60 * 1000;


### PR DESCRIPTION
Do the ISO downloading and kubeconfig downloading with the browser
instead of with the API, like a real user would do. Works only with
Chrome (not with Firefox or Electron!).