### PR TITLE
Fail faster

### DIFF
--- a/cypress/integration-qe/e2e-createNewCluster.spec.js
+++ b/cypress/integration-qe/e2e-createNewCluster.spec.js
@@ -9,6 +9,8 @@ import {
   OCM_USER,
 } from './shared';
 
+import { ISO_DOWNLOAD_TIMEOUT } from './constants';
+
 import { writeCookieToDisk } from './ocmShared';
 
 describe('Flow', () => {
@@ -30,7 +32,11 @@ describe('Flow', () => {
     cy.get('#button-download-discovery-iso').click(); // open the dialog
     cy.wait(10 * 1000); // wait few seconds otherwise HTTP 409 will be raised
     cy.get('.pf-c-modal-box__footer > .pf-m-primary').click(); // "Get Discovery ISO"
-    downloadFileWithChrome('button[data-test-id="download-iso-btn"]', ISO_PATTERN);
+    downloadFileWithChrome(
+      'button[data-test-id="download-iso-btn"]',
+      ISO_PATTERN,
+      ISO_DOWNLOAD_TIMEOUT,
+    );
     cy.get('button[data-test-id="close-iso-btn"]').click(); // now close the dialog
   });
 

--- a/cypress/integration/constants.js
+++ b/cypress/integration/constants.js
@@ -10,7 +10,9 @@ export const VALIDATE_CHANGES_TIMEOUT = 10 * 1000;
 export const INSTALL_PREPARATION_TIMEOUT = 60 * 1000;
 // timeout for generating ISO
 export const GENERATE_ISO_TIMEOUT = 2 * 60 * 1000;
-// timeout for downloading files (such as ISO images)
-export const FILE_DOWNLOAD_TIMEOUT = 30 * 60 * 1000;
+// timeout for downloading files
+export const FILE_DOWNLOAD_TIMEOUT = 60 * 1000;
+// timeout for downloading the ISO image
+export const ISO_DOWNLOAD_TIMEOUT = 30 * 60 * 1000;
 // timeout for cluster instation to finish - 1 hour
 export const CLUSTER_CREATION_TIMEOUT = 60 * 60 * 1000;

--- a/cypress/integration/e2e-installCluster.spec.js
+++ b/cypress/integration/e2e-installCluster.spec.js
@@ -21,11 +21,8 @@ describe('Run install', () => {
     openCluster(CLUSTER_NAME);
   });
 
-  it('start installation', () => {
+  it('run installation', () => {
     startClusterInstallation();
-  });
-
-  it('wait for cluster installation...', () => {
     waitForClusterInstallation();
   });
 });

--- a/cypress/integration/shared.js
+++ b/cypress/integration/shared.js
@@ -4,6 +4,7 @@ import {
   CLUSTER_CREATION_TIMEOUT,
   HOST_DISCOVERY_TIMEOUT,
   HOST_REGISTRATION_TIMEOUT,
+  INSTALL_PREPARATION_TIMEOUT,
   FILE_DOWNLOAD_TIMEOUT,
 } from './constants';
 
@@ -155,7 +156,11 @@ export const generateIso = (sshPubKey) => {
   cy.get('button[data-test-id="close-iso-btn"]').click(); // now close the dialog
 };
 
-export const downloadFileWithChrome = (downloadButton, resultantFilename) => {
+export const downloadFileWithChrome = (
+  downloadButton,
+  resultantFilename,
+  timeout = FILE_DOWNLOAD_TIMEOUT,
+) => {
   // NOTE: This works only with Chrome, where the default behavior is:
   //  1) It starts the download without popping up a save dialog (which would require automating native windows)
   //  2) It caches to a temporary location, and when the download is complete it moves the file to ~/Downloads
@@ -168,7 +173,7 @@ export const downloadFileWithChrome = (downloadButton, resultantFilename) => {
 
   // wait until the file shows up, to know that the download finshed
   cy.exec(`while [ ! -f ${resultantFilename} ]; do sleep 1; done`, {
-    timeout: FILE_DOWNLOAD_TIMEOUT,
+    timeout: timeout,
   }).should((result) => {
     expect(result.code).to.be.eq(0);
   });
@@ -212,11 +217,10 @@ export const startClusterInstallation = () => {
     expect($elem).to.be.enabled;
   });
   cy.get('button[name="install"]').click();
-  // wait for the progress description to say "Installing" [temporarily comented out because
-  // there is no div.pf-c-progress__description any more...]
-  // cy.contains('div.pf-c-progress__description', 'Installing', {
-  //   timeout: INSTALL_PREPARATION_TIMEOUT,
-  // });
+  // wait for the progress description to say "Installing"
+  cy.contains('#cluster-progress-status-value', 'Installing', {
+    timeout: INSTALL_PREPARATION_TIMEOUT,
+  });
 };
 
 export const waitForClusterInstallation = () => {


### PR DESCRIPTION
This change will fail if the cluster installation didn't start, and
won't wait for it to finish even if it didn't start. It also waits
less for files to download, and only waits long for the ISO file
download.