### PR TITLE
Timeout for start installation

### DIFF
--- a/cypress/integration/constants.js
+++ b/cypress/integration/constants.js
@@ -6,6 +6,8 @@ export const HOST_REGISTRATION_TIMEOUT = 20 * 60 * 1000;
 export const HOST_DISCOVERY_TIMEOUT = 30 * 1000;
 // timeout for validate changes - 10 seconds
 export const VALIDATE_CHANGES_TIMEOUT = 10 * 1000;
+// timeout for start installation to be enabled
+export const START_INSTALLATION_TIMEOUT = 2.5 * 60 * 1000;
 // timeout for install preparation - 1 minute
 export const INSTALL_PREPARATION_TIMEOUT = 2 * 60 * 1000;
 // timeout for generating ISO

--- a/cypress/integration/shared.js
+++ b/cypress/integration/shared.js
@@ -6,6 +6,7 @@ import {
   HOST_REGISTRATION_TIMEOUT,
   INSTALL_PREPARATION_TIMEOUT,
   FILE_DOWNLOAD_TIMEOUT,
+  START_INSTALLATION_TIMEOUT,
 } from './constants';
 
 export const testInfraClusterName = 'test-infra-cluster';
@@ -213,7 +214,7 @@ export const checkValidationMessage = (cy, expectedMsg) => {
 
 export const startClusterInstallation = () => {
   // wait up to 10 seconds for the install button to be enabled
-  cy.get('button[name="install"]', { timeout: VALIDATE_CHANGES_TIMEOUT }).should(($elem) => {
+  cy.get('button[name="install"]', { timeout: START_INSTALLATION_TIMEOUT }).should(($elem) => {
     expect($elem).to.be.enabled;
   });
   cy.get('button[name="install"]').click();


### PR DESCRIPTION
Increasing the timeout for the "Install Cluster" button to become
enabled. When DHCP is enabled is seems to take more time for the
button to be clickable, so increasing the timeout to 1 minute.