### PR TITLE
 Waiting for host to be Known

### DIFF
--- a/cypress/integration-qe/e2e-enterClusterSpecs.spec.js
+++ b/cypress/integration-qe/e2e-enterClusterSpecs.spec.js
@@ -28,8 +28,8 @@ describe('Enter cluster details', () => {
     waitForHostsSubnet(cy);
   });
 
-  it('wait for all hosts to reach pending input state', () => {
-    waitForPendingInputState(cy);
+  it('wait for all hosts to reach known state', () => {
+    waitForHostsToBeKnown(cy);
   });
 
   it('can set the base domain name', () => {


### PR DESCRIPTION
The DHCP feature has the nodes moved to Known state after discovery, causing the test to fail.
Currently is uses Pending Input state.
This moves the test to wait for the Known state