### PR TITLE
Updates to the shared infrastructure

### DIFF
--- a/cypress/integration-qe/e2e-createNewCluster.spec.js
+++ b/cypress/integration-qe/e2e-createNewCluster.spec.js
@@ -21,7 +21,7 @@ describe('Flow', () => {
   });
 
   it('create a cluster named ' + CLUSTER_NAME, () => {
-    createCluster(CLUSTER_NAME, PULL_SECRET);
+    createCluster(cy, CLUSTER_NAME, PULL_SECRET);
   });
 
   it('generate the ISO', () => {

--- a/cypress/integration/app.spec.js
+++ b/cypress/integration/app.spec.js
@@ -10,7 +10,7 @@ describe('Application', () => {
   it('has basic structure', () => {
     cy.visit('/');
 
-    cy.get('h1').contains('Managed Clusters');
+    cy.get('h1').contains('Assisted Bare Metal Clusters');
     cy.get('.pf-c-brand').should(
       'have.attr',
       'alt',

--- a/cypress/integration/managedClusters.spec.js
+++ b/cypress/integration/managedClusters.spec.js
@@ -1,18 +1,22 @@
 import {
+  createCluster,
   createDummyCluster,
+  cancelDummyCluster,
   deleteDummyCluster,
   testInfraClusterName,
   testClusterLinkSelector,
   assertTestClusterPresence,
   clusterTableCellSelector,
   getClusterNameLinkSelector,
+  kebabSelector,
+  PULL_SECRET,
 } from './shared';
 
 const clustersTableHeaders = ['Name', 'Base domain', 'Version', 'Status', 'Hosts'];
 
 describe('Managed Clusters list', () => {
   const clusterName = 'test-dummy-cluster';
-  const clusterColHeaderSelector = (label) => `[data-label="${label}"] > .pf-c-table__button`;
+  const clusterColHeaderSelector = (label) => `th[data-label="${label}"] > button`;
 
   beforeEach(() => {
     assertTestClusterPresence(cy);
@@ -20,7 +24,7 @@ describe('Managed Clusters list', () => {
   });
 
   it('can render', () => {
-    cy.get('h1').contains('Managed Clusters');
+    cy.get('h1').contains('Assisted Bare Metal Clusters');
   });
 
   it('has test-infra-cluster with visible columns', () => {
@@ -31,18 +35,31 @@ describe('Managed Clusters list', () => {
 
   it('can create and delete dummy cluster', () => {
     // still single cluster in the list
-    cy.get('#pf-toggle-id-0').click(); // open kebab
+    cy.get(kebabSelector(1)).click(); // open kebab
     cy.get('.pf-c-dropdown__menu-item').should('have.length', 1);
 
-    // create
-    createDummyCluster(cy, clusterName);
+    // create and cancel the dummy cluster
+    createDummyCluster(cy, clusterName, PULL_SECRET);
+    cancelDummyCluster(cy);
+
+    // do not allow two clusters of the same name
+    createDummyCluster(cy, testInfraClusterName, PULL_SECRET);
+    cy.get('button[name="save"]').click();
+    cy.contains('#form-input-name-field-helper', 'is already taken');
+    cancelDummyCluster(cy, testInfraClusterName);
+
+    // create the dummy cluster
+    createCluster(cy, clusterName, PULL_SECRET);
+
+    // Close
+    cy.get(':nth-child(4) > .pf-c-button').click();
 
     // Managed Clusters list
     cy.get('[data-label="Name"] > a').should('have.length', 2);
     cy.get(clusterTableCellSelector(1, 'Name')).contains(clusterName);
     cy.get(clusterTableCellSelector(2, 'Name')).contains(testInfraClusterName); // other cells of the test-infra-cluster are tested within assertTestClusterPresence()
     cy.get(clusterTableCellSelector(1, 'Base domain')).contains('-');
-    cy.get(clusterTableCellSelector(1, 'Version')).contains('4.5');
+    cy.get(clusterTableCellSelector(1, 'Version')).contains('4.6');
     cy.get(clusterTableCellSelector(1, 'Status')).contains('Draft'); // insufficient ~ Draft
     cy.get(clusterTableCellSelector(1, 'Hosts')).contains(0);
 
@@ -61,9 +78,10 @@ describe('Managed Clusters list', () => {
       cy.get(clusterColHeaderSelector(header)).click();
       cy.get(clusterColHeaderSelector(header)).click();
     });
+    cy.get(clusterColHeaderSelector('Name')).click(); // sort by name again
 
     // Delete
-    deleteDummyCluster(cy, 2, clusterName);
+    deleteDummyCluster(cy, 1, clusterName);
 
     // we are back to inital state with just a single cluster
     assertTestClusterPresence(cy); // fail fast here to verify that just the dummy cluster is deleted
@@ -71,8 +89,10 @@ describe('Managed Clusters list', () => {
 
   it('can filter clusters', () => {
     // create
-    createDummyCluster(cy, 'cluster-aa-0');
-    createDummyCluster(cy, 'cluster-bb-0');
+    createCluster(cy, 'cluster-aa-0', PULL_SECRET);
+    createCluster(cy, 'cluster-bb-0', PULL_SECRET);
+    // Close
+    cy.get(':nth-child(4) > .pf-c-button').click();
 
     // all visible
     cy.get(testClusterLinkSelector);
@@ -101,17 +121,20 @@ describe('Managed Clusters list', () => {
 
     // switch status
     cy.get('.pf-c-toolbar__item .pf-c-select__toggle').click();
-    cy.get('#Draft').click();
+    // cy.get('#Draft').click(); // FIXME: identifier no longer exists
+    cy.contains('.pf-c-check__label', 'Draft').click();
     cy.get(testClusterLinkSelector).should('not.exist');
     cy.get(getClusterNameLinkSelector('cluster-aa-0'));
     cy.get(getClusterNameLinkSelector('cluster-bb-0'));
 
-    cy.get('#Ready').click();
+    // cy.get('#Ready').click(); // FIXME: identifier no longer exists
+    cy.contains('.pf-c-check__label', 'Ready').click();
     cy.get(testClusterLinkSelector);
     cy.get(getClusterNameLinkSelector('cluster-aa-0'));
     cy.get(getClusterNameLinkSelector('cluster-bb-0'));
 
-    cy.get('#Draft').click();
+    // cy.get('#Draft').click(); // FIXME: identifier no longer exists
+    cy.contains('.pf-c-check__label', 'Draft').click();
     cy.get(testClusterLinkSelector);
     cy.get(getClusterNameLinkSelector('cluster-aa-0')).should('not.exist');
     cy.get(getClusterNameLinkSelector('cluster-bb-0')).should('not.exist');


### PR DESCRIPTION
Updates to test-infra

Fixing the tests for test-infra, and unifying the code used by test-
infra and the QEs.

Changes to createCluster and createDummyCluster:
1) createDummyCluster will feed in the cluster name and pull secret,
   and will leave you in the create cluster screen.
2) createDummyCluster will not finish creating the cluster, and the
   user will have the option to call cancelDummyCluster or complete
   the creation process.
3) createCluster uses createDummyCluster in order to prevent code
   duplication. Most scenarios will call createCluster.