### PR TITLE
Increate cluster creation timeout

### DIFF
--- a/cypress/integration/constants.js
+++ b/cypress/integration/constants.js
@@ -16,5 +16,5 @@ export const GENERATE_ISO_TIMEOUT = 2 * 60 * 1000;
 export const FILE_DOWNLOAD_TIMEOUT = 60 * 1000;
 // timeout for downloading the ISO image
 export const ISO_DOWNLOAD_TIMEOUT = 30 * 60 * 1000;
-// timeout for cluster instation to finish - 1 hour
-export const CLUSTER_CREATION_TIMEOUT = 60 * 60 * 1000;
+// timeout for cluster installation to finish - 1.5 hour
+export const CLUSTER_CREATION_TIMEOUT = 90 * 60 * 1000;


### PR DESCRIPTION
Due to changes in the installer - it now waits for the cluster
version to be up, so installation takes much longer. This patch
increases the timeout.