### PR TITLE
update the ID if the dhcpvip button

### DIFF
--- a/cypress/integration/shared.js
+++ b/cypress/integration/shared.js
@@ -424,7 +424,7 @@ export const disableDhcpVip = (cy, apiVip = null, ingressVip = null) => {
 export const enableDhcpVip = (cy) => {
   getDhcpVipState(cy).then((state) => {
     if (!state) {
-      cy.get('#form-input-vipDhcpAllocation-field-off').click();
+      cy.get('#form-input-vipDhcpAllocation-field').click();
     }
   });
 };


### PR DESCRIPTION
The dhcp vip button is enabled by default. The ID
was updated. Adjusting automation.

Signed-off-by: Alexander Chuzhoy <achuzhoy@redhat.com>