### PR TITLE
MGMT-2786: ocp-metal-ui-template.yaml: Store namespace under quotes

### DIFF
--- a/deploy/ocp-metal-ui-template.yaml
+++ b/deploy/ocp-metal-ui-template.yaml
@@ -2,7 +2,7 @@ kind: Service
 apiVersion: v1
 metadata:
   name: ocp-metal-ui
-  namespace: __NAMESPACE__
+  namespace: "__NAMESPACE__"
 spec:
   type: LoadBalancer
   ports:
@@ -49,7 +49,7 @@ kind: Deployment
 apiVersion: apps/v1
 metadata:
   name: ocp-metal-ui
-  namespace: __NAMESPACE__
+  namespace: "__NAMESPACE__"
 spec:
   replicas: 1
   selector:


### PR DESCRIPTION
Namespace is generated in each CI run by Jenkinsfile (to support multiple
environments).

In cases it contains only numbers, ui can't be deployed since in the
deploy_ui.yaml file the namespace is unquoted.